### PR TITLE
MTDSA-29724 Use Pattern.quote to obtain the literal string so special characters can be picked up

### DIFF
--- a/app/shared/config/rewriters/EndpointSummaryRewriter.scala
+++ b/app/shared/config/rewriters/EndpointSummaryRewriter.scala
@@ -19,6 +19,7 @@ package shared.config.rewriters
 import shared.config.SharedAppConfig
 import shared.config.rewriters.DocumentationRewriters.CheckAndRewrite
 
+import java.util.regex.Pattern
 import javax.inject.{Inject, Singleton}
 
 @Singleton class EndpointSummaryRewriter @Inject() (appConfig: SharedAppConfig) {
@@ -41,17 +42,19 @@ import javax.inject.{Inject, Singleton}
     },
     rewrite = (_, _, yaml) => {
       if (rewriteSummaryRegex.findAllIn(yaml).length == 1) {
-        val maybeLine = rewriteSummaryRegex.findFirstIn(yaml)
+        val maybeLine: Option[String] = rewriteSummaryRegex.findFirstIn(yaml)
         val rewritten = maybeLine
           .collect {
             case line if !line.toLowerCase.contains("[test only]") =>
-              val components = line.split("summary: ")
-              val whitespace = components(0)
-              val summary    = components(1).replace("\"", "")
+              val components: Array[String] = line.split("summary: ")
+              val whitespace: String = components(0)
+              val summary: String = components(1).replace("\"", "")
 
-              val replacement = s"""${whitespace}summary: "$summary [test only]""""
+              val replacement: String = s"""${whitespace}summary: "$summary [test only]""""
 
-              yaml.replaceFirst(line, replacement)
+              val literalString: String = Pattern.quote(line)
+
+              yaml.replaceFirst(literalString, replacement)
           }
 
         rewritten.getOrElse(yaml)

--- a/resources/public/api/conf/2.0/cgt_residential_non_ppd_create_amend.yaml
+++ b/resources/public/api/conf/2.0/cgt_residential_non_ppd_create_amend.yaml
@@ -1,4 +1,4 @@
-summary: Create and Amend CGT Residential Property Disposals (non-PPD) [test only]
+summary: Create and Amend CGT Residential Property Disposals (non-PPD)
 description: |
   This endpoint enables you to submit residential property disposals that are not payment for property disposal 
   (not reported via the 'Report and pay Capital Gains Tax on UK property' service) 

--- a/resources/public/api/conf/2.0/cgt_residential_non_ppd_delete.yaml
+++ b/resources/public/api/conf/2.0/cgt_residential_non_ppd_delete.yaml
@@ -1,4 +1,4 @@
-summary: Delete CGT Residential Property Disposals (non-PPD) [test only]
+summary: Delete CGT Residential Property Disposals (non-PPD)
 description: |
   This endpoint enables you to delete a Capital Gains Tax (CGT) residential property disposal for a non payment for 
   property disposal (non-PPD) data submission for a specified taxable entity ID and tax year.

--- a/resources/public/api/conf/2.0/cgt_residential_overrides_ppd_create_amend.yaml
+++ b/resources/public/api/conf/2.0/cgt_residential_overrides_ppd_create_amend.yaml
@@ -1,4 +1,4 @@
-summary: Create and Amend 'Report and Pay Capital Gains Tax on Residential Property' Overrides (PPD) [test only]
+summary: Create and Amend 'Report and Pay Capital Gains Tax on Residential Property' Overrides (PPD)
 description: |
   This endpoint enables you to override residential property disposals submissions previously submitted via the HMRC 
   'Report and pay Capital Gains Tax on UK property' service (payment for property disposal or PPD) for a given National 

--- a/resources/public/api/conf/2.0/cgt_residential_overrides_ppd_delete.yaml
+++ b/resources/public/api/conf/2.0/cgt_residential_overrides_ppd_delete.yaml
@@ -1,4 +1,4 @@
-summary: Delete 'Report and Pay Capital Gains Tax on Residential Property' Overrides (PPD) [test only]
+summary: Delete 'Report and Pay Capital Gains Tax on Residential Property' Overrides (PPD)
 description: |
   This endpoint enables you to delete user submitted overrides for previously submitted disposals for payment for 
   property disposal (PPD) reported via the HMRC 'Report and pay Capital Gains Tax on UK property' service.

--- a/test/shared/config/rewriters/EndpointSummaryRewriterSpec.scala
+++ b/test/shared/config/rewriters/EndpointSummaryRewriterSpec.scala
@@ -60,6 +60,16 @@ class EndpointSummaryRewriterSpec extends UnitSpec with MockSharedAppConfig {
         val result = rewrite("", "", "  summary: Create and Amend employment expenses")
         result shouldBe """  summary: "Create and Amend employment expenses [test only]""""
       }
+
+      "return the rewritten summary when it contains parentheses" in {
+        val result = rewrite("", "", "summary: Create and Amend CGT Residential Property Disposals (non-PPD)")
+        result shouldBe """summary: "Create and Amend CGT Residential Property Disposals (non-PPD) [test only]""""
+      }
+
+      "return the rewritten summary when it contains square brackets" in {
+        val result = rewrite("", "", "summary: Create and Amend CGT Residential Property Disposals [non-PPD]")
+        result shouldBe """summary: "Create and Amend CGT Residential Property Disposals [non-PPD] [test only]""""
+      }
     }
 
     "the yaml summary is already in quotes" should {


### PR DESCRIPTION
The issue is not with the regex but that the literal string is not used which causes issues with special characters. Using Pattern.quote we can use the literal string in replaceFirst so whatever the input string has i.e. parentheses, square brackets or even if we want to use question marks, it will work as expected. Added tests with parentheses and square brackets.