### PR TITLE
[MTDSA-30439]: Remove Tax year specific Ifs config to use Ifs config

### DIFF
--- a/app/shared/config/SharedAppConfig.scala
+++ b/app/shared/config/SharedAppConfig.scala
@@ -41,7 +41,6 @@ class SharedAppConfig @Inject() (val config: ServicesConfig, protected[config] v
 
   def desDownstreamConfig: DownstreamConfig          = downstreamConfig("des")
   def ifsDownstreamConfig: DownstreamConfig          = downstreamConfig("ifs")
-  def tysIfsDownstreamConfig: DownstreamConfig       = downstreamConfig("tys-ifs")
   def hipDownstreamConfig: BasicAuthDownstreamConfig = basicAuthDownstreamConfig("hip")
 
   // API Config

--- a/app/shared/connectors/DownstreamUri.scala
+++ b/app/shared/connectors/DownstreamUri.scala
@@ -34,9 +34,6 @@ object DownstreamUri {
   def IfsUri[Resp](value: String)(implicit appConfig: SharedAppConfig): DownstreamUri[Resp] =
     withStandardStrategy(value, appConfig.ifsDownstreamConfig)
 
-  def TaxYearSpecificIfsUri[Resp](value: String)(implicit appConfig: SharedAppConfig): DownstreamUri[Resp] =
-    withStandardStrategy(value, appConfig.tysIfsDownstreamConfig)
-
   def HipUri[Resp](path: String)(implicit appConfig: SharedAppConfig): DownstreamUri[Resp] =
     DownstreamUri(path, DownstreamStrategy.basicAuthStrategy(appConfig.hipDownstreamConfig))
 

--- a/app/v1/otherCgt/createAmend/CreateAmendOtherCgtConnector.scala
+++ b/app/v1/otherCgt/createAmend/CreateAmendOtherCgtConnector.scala
@@ -17,7 +17,7 @@
 package v1.otherCgt.createAmend
 
 import shared.config.SharedAppConfig
-import shared.connectors.DownstreamUri.{IfsUri, TaxYearSpecificIfsUri}
+import shared.connectors.DownstreamUri.IfsUri
 import shared.connectors.{BaseDownstreamConnector, DownstreamOutcome, DownstreamUri}
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.http.client.HttpClientV2
@@ -39,7 +39,7 @@ class CreateAmendOtherCgtConnector @Inject() (val http: HttpClientV2, val appCon
 
     val downstreamUri: DownstreamUri[Unit] =
       if (taxYear.useTaxYearSpecificApi) {
-        TaxYearSpecificIfsUri[Unit](s"income-tax/income/disposals/other-gains/${taxYear.asTysDownstream}/${nino.nino}")
+        IfsUri[Unit](s"income-tax/income/disposals/other-gains/${taxYear.asTysDownstream}/${nino.nino}")
       } else {
         IfsUri[Unit](s"income-tax/income/disposals/other-gains/${nino.nino}/${taxYear.asMtd}")
       }

--- a/app/v1/otherCgt/delete/DeleteOtherCgtConnector.scala
+++ b/app/v1/otherCgt/delete/DeleteOtherCgtConnector.scala
@@ -17,7 +17,7 @@
 package v1.otherCgt.delete
 
 import shared.config.SharedAppConfig
-import shared.connectors.DownstreamUri.{IfsUri, TaxYearSpecificIfsUri}
+import shared.connectors.DownstreamUri.IfsUri
 import shared.connectors.{BaseDownstreamConnector, DownstreamOutcome}
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.http.client.HttpClientV2
@@ -39,7 +39,7 @@ class DeleteOtherCgtConnector @Inject() (val http: HttpClientV2, val appConfig: 
     import request._
 
     val downstreamUri = if (taxYear.useTaxYearSpecificApi) {
-      TaxYearSpecificIfsUri[Unit](
+      IfsUri[Unit](
         s"income-tax/income/disposals/other-gains/${taxYear.asTysDownstream}/${nino.value}"
       )
     } else {

--- a/app/v1/otherCgt/retrieve/RetrieveOtherCgtConnector.scala
+++ b/app/v1/otherCgt/retrieve/RetrieveOtherCgtConnector.scala
@@ -17,7 +17,7 @@
 package v1.otherCgt.retrieve
 
 import shared.config.SharedAppConfig
-import shared.connectors.DownstreamUri.{IfsUri, TaxYearSpecificIfsUri}
+import shared.connectors.DownstreamUri.IfsUri
 import shared.connectors.{BaseDownstreamConnector, DownstreamOutcome, DownstreamUri}
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.http.client.HttpClientV2
@@ -42,7 +42,7 @@ class RetrieveOtherCgtConnector @Inject() (val http: HttpClientV2, val appConfig
 
     val downstreamUri: DownstreamUri[DownstreamResp] = taxYear match {
       case ty if ty.useTaxYearSpecificApi =>
-        TaxYearSpecificIfsUri(s"income-tax/income/disposals/other-gains/${taxYear.asTysDownstream}/${nino.value}")
+        IfsUri(s"income-tax/income/disposals/other-gains/${taxYear.asTysDownstream}/${nino.value}")
       case _ =>
         IfsUri(s"income-tax/income/disposals/other-gains/${nino.value}/${taxYear.asMtd}")
     }

--- a/app/v1/residentialPropertyDisposals/createAmendCgtPpdOverrides/CreateAmendCgtPpdOverridesConnector.scala
+++ b/app/v1/residentialPropertyDisposals/createAmendCgtPpdOverrides/CreateAmendCgtPpdOverridesConnector.scala
@@ -18,7 +18,7 @@ package v1.residentialPropertyDisposals.createAmendCgtPpdOverrides
 
 import com.google.inject.Singleton
 import shared.config.SharedAppConfig
-import shared.connectors.DownstreamUri.{IfsUri, TaxYearSpecificIfsUri}
+import shared.connectors.DownstreamUri.IfsUri
 import shared.connectors.{BaseDownstreamConnector, DownstreamOutcome}
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.http.client.HttpClientV2
@@ -40,7 +40,7 @@ class CreateAmendCgtPpdOverridesConnector @Inject() (val http: HttpClientV2, val
 
     val downstreamUri =
       if (taxYear.useTaxYearSpecificApi) {
-        TaxYearSpecificIfsUri[Unit](s"income-tax/income/disposals/residential-property/ppd/${taxYear.asTysDownstream}/$nino")
+        IfsUri[Unit](s"income-tax/income/disposals/residential-property/ppd/${taxYear.asTysDownstream}/$nino")
       } else {
         IfsUri[Unit](s"income-tax/income/disposals/residential-property/ppd/$nino/${taxYear.asMtd}")
       }

--- a/app/v1/residentialPropertyDisposals/createAmendNonPpd/CreateAmendCgtResidentialPropertyDisposalsConnector.scala
+++ b/app/v1/residentialPropertyDisposals/createAmendNonPpd/CreateAmendCgtResidentialPropertyDisposalsConnector.scala
@@ -17,7 +17,7 @@
 package v1.residentialPropertyDisposals.createAmendNonPpd
 
 import shared.config.SharedAppConfig
-import shared.connectors.DownstreamUri.{IfsUri, TaxYearSpecificIfsUri}
+import shared.connectors.DownstreamUri.IfsUri
 import shared.connectors.{BaseDownstreamConnector, DownstreamOutcome}
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.http.client.HttpClientV2
@@ -39,7 +39,7 @@ class CreateAmendCgtResidentialPropertyDisposalsConnector @Inject() (val http: H
     import shared.connectors.httpparsers.StandardDownstreamHttpParser._
 
     val uri = if (taxYear.useTaxYearSpecificApi) {
-      TaxYearSpecificIfsUri[Unit](s"income-tax/income/disposals/residential-property/${taxYear.asTysDownstream}/${nino.nino}")
+      IfsUri[Unit](s"income-tax/income/disposals/residential-property/${taxYear.asTysDownstream}/${nino.nino}")
     } else {
       // Pre-tys uses MTD tax year format
       IfsUri[Unit](s"income-tax/income/disposals/residential-property/${nino.nino}/${taxYear.asMtd}")

--- a/app/v1/residentialPropertyDisposals/deleteCgtPpdOverrides/DeleteCgtPpdOverridesConnector.scala
+++ b/app/v1/residentialPropertyDisposals/deleteCgtPpdOverrides/DeleteCgtPpdOverridesConnector.scala
@@ -17,7 +17,7 @@
 package v1.residentialPropertyDisposals.deleteCgtPpdOverrides
 
 import shared.config.SharedAppConfig
-import shared.connectors.DownstreamUri.{DesUri, TaxYearSpecificIfsUri}
+import shared.connectors.DownstreamUri.{DesUri, IfsUri}
 import shared.connectors.{BaseDownstreamConnector, DownstreamOutcome}
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.http.client.HttpClientV2
@@ -39,7 +39,7 @@ class DeleteCgtPpdOverridesConnector @Inject() (val http: HttpClientV2, val appC
     import request._
 
     val downstreamUri = if (taxYear.useTaxYearSpecificApi) {
-      TaxYearSpecificIfsUri[Unit](s"income-tax/income/disposals/residential-property/ppd/${taxYear.asTysDownstream}/${nino.nino}")
+      IfsUri[Unit](s"income-tax/income/disposals/residential-property/ppd/${taxYear.asTysDownstream}/${nino.nino}")
     } else {
       DesUri[Unit](s"income-tax/income/disposals/residential-property/ppd/${nino.nino}/${taxYear.asMtd}")
     }

--- a/app/v1/residentialPropertyDisposals/deleteNonPpd/DeleteCgtNonPpdConnector.scala
+++ b/app/v1/residentialPropertyDisposals/deleteNonPpd/DeleteCgtNonPpdConnector.scala
@@ -17,7 +17,7 @@
 package v1.residentialPropertyDisposals.deleteNonPpd
 
 import shared.config.SharedAppConfig
-import shared.connectors.DownstreamUri.{IfsUri, TaxYearSpecificIfsUri}
+import shared.connectors.DownstreamUri.IfsUri
 import shared.connectors.httpparsers.StandardDownstreamHttpParser._
 import shared.connectors.{BaseDownstreamConnector, DownstreamOutcome}
 import uk.gov.hmrc.http.HeaderCarrier
@@ -38,7 +38,7 @@ class DeleteCgtNonPpdConnector @Inject() (val http: HttpClientV2, val appConfig:
     import request._
 
     val downstreamUri = if (taxYear.useTaxYearSpecificApi) {
-      TaxYearSpecificIfsUri[Unit](s"income-tax/income/disposals/residential-property/${taxYear.asTysDownstream}/${nino.value}")
+      IfsUri[Unit](s"income-tax/income/disposals/residential-property/${taxYear.asTysDownstream}/${nino.value}")
     } else {
       // Note: tax year is in MTD format
       IfsUri[Unit](s"income-tax/income/disposals/residential-property/${nino.value}/${taxYear.asMtd}")

--- a/app/v1/residentialPropertyDisposals/retrieveAll/RetrieveAllResidentialPropertyCgtConnector.scala
+++ b/app/v1/residentialPropertyDisposals/retrieveAll/RetrieveAllResidentialPropertyCgtConnector.scala
@@ -17,7 +17,7 @@
 package v1.residentialPropertyDisposals.retrieveAll
 
 import shared.config.SharedAppConfig
-import shared.connectors.DownstreamUri.{DesUri, TaxYearSpecificIfsUri}
+import shared.connectors.DownstreamUri.{DesUri, IfsUri}
 import shared.connectors.{BaseDownstreamConnector, DownstreamOutcome, DownstreamUri}
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.http.client.HttpClientV2
@@ -46,7 +46,7 @@ class RetrieveAllResidentialPropertyCgtConnector @Inject() (val http: HttpClient
 
     val downstreamUri: DownstreamUri[DownstreamResp] = taxYear match {
       case ty if ty.useTaxYearSpecificApi =>
-        TaxYearSpecificIfsUri(s"income-tax/income/disposals/residential-property/${taxYear.asTysDownstream}/${nino.value}")
+        IfsUri(s"income-tax/income/disposals/residential-property/${taxYear.asTysDownstream}/${nino.value}")
       case _ =>
         DesUri(s"income-tax/income/disposals/residential-property/${nino.value}/${taxYear.asMtd}")
     }

--- a/app/v2/otherCgt/createAmend/CreateAmendOtherCgtConnector.scala
+++ b/app/v2/otherCgt/createAmend/CreateAmendOtherCgtConnector.scala
@@ -17,7 +17,7 @@
 package v2.otherCgt.createAmend
 
 import shared.config.SharedAppConfig
-import shared.connectors.DownstreamUri.{IfsUri, TaxYearSpecificIfsUri}
+import shared.connectors.DownstreamUri.IfsUri
 import shared.connectors.{BaseDownstreamConnector, DownstreamOutcome, DownstreamUri}
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.http.client.HttpClientV2
@@ -39,7 +39,7 @@ class CreateAmendOtherCgtConnector @Inject() (val http: HttpClientV2, val appCon
 
     val downstreamUri: DownstreamUri[Unit] =
       if (taxYear.useTaxYearSpecificApi) {
-        TaxYearSpecificIfsUri[Unit](s"income-tax/income/disposals/other-gains/${taxYear.asTysDownstream}/${nino.nino}")
+        IfsUri[Unit](s"income-tax/income/disposals/other-gains/${taxYear.asTysDownstream}/${nino.nino}")
       } else {
         IfsUri[Unit](s"income-tax/income/disposals/other-gains/${nino.nino}/${taxYear.asMtd}")
       }

--- a/app/v2/otherCgt/delete/DeleteOtherCgtConnector.scala
+++ b/app/v2/otherCgt/delete/DeleteOtherCgtConnector.scala
@@ -17,7 +17,7 @@
 package v2.otherCgt.delete
 
 import shared.config.SharedAppConfig
-import shared.connectors.DownstreamUri.{IfsUri, TaxYearSpecificIfsUri}
+import shared.connectors.DownstreamUri.IfsUri
 import shared.connectors.{BaseDownstreamConnector, DownstreamOutcome}
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.http.client.HttpClientV2
@@ -39,7 +39,7 @@ class DeleteOtherCgtConnector @Inject() (val http: HttpClientV2, val appConfig: 
     import request._
 
     val downstreamUri = if (taxYear.useTaxYearSpecificApi) {
-      TaxYearSpecificIfsUri[Unit](
+      IfsUri[Unit](
         s"income-tax/income/disposals/other-gains/${taxYear.asTysDownstream}/${nino.value}"
       )
     } else {

--- a/app/v2/otherCgt/retrieve/RetrieveOtherCgtConnector.scala
+++ b/app/v2/otherCgt/retrieve/RetrieveOtherCgtConnector.scala
@@ -17,7 +17,7 @@
 package v2.otherCgt.retrieve
 
 import shared.config.SharedAppConfig
-import shared.connectors.DownstreamUri.{IfsUri, TaxYearSpecificIfsUri}
+import shared.connectors.DownstreamUri.IfsUri
 import shared.connectors.{BaseDownstreamConnector, DownstreamOutcome, DownstreamUri}
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.http.client.HttpClientV2
@@ -42,7 +42,7 @@ class RetrieveOtherCgtConnector @Inject() (val http: HttpClientV2, val appConfig
 
     val downstreamUri: DownstreamUri[DownstreamResp] = taxYear match {
       case ty if ty.useTaxYearSpecificApi =>
-        TaxYearSpecificIfsUri(s"income-tax/income/disposals/other-gains/${taxYear.asTysDownstream}/${nino.value}")
+        IfsUri(s"income-tax/income/disposals/other-gains/${taxYear.asTysDownstream}/${nino.value}")
       case _ =>
         IfsUri(s"income-tax/income/disposals/other-gains/${nino.value}/${taxYear.asMtd}")
     }

--- a/app/v2/residentialPropertyDisposals/createAmendCgtPpdOverrides/CreateAmendCgtPpdOverridesConnector.scala
+++ b/app/v2/residentialPropertyDisposals/createAmendCgtPpdOverrides/CreateAmendCgtPpdOverridesConnector.scala
@@ -18,7 +18,7 @@ package v2.residentialPropertyDisposals.createAmendCgtPpdOverrides
 
 import com.google.inject.Singleton
 import shared.config.SharedAppConfig
-import shared.connectors.DownstreamUri.{IfsUri, TaxYearSpecificIfsUri}
+import shared.connectors.DownstreamUri.IfsUri
 import shared.connectors.{BaseDownstreamConnector, DownstreamOutcome}
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.http.client.HttpClientV2
@@ -40,7 +40,7 @@ class CreateAmendCgtPpdOverridesConnector @Inject() (val http: HttpClientV2, val
 
     val downstreamUri =
       if (taxYear.useTaxYearSpecificApi) {
-        TaxYearSpecificIfsUri[Unit](s"income-tax/income/disposals/residential-property/ppd/${taxYear.asTysDownstream}/$nino")
+        IfsUri[Unit](s"income-tax/income/disposals/residential-property/ppd/${taxYear.asTysDownstream}/$nino")
       } else {
         IfsUri[Unit](s"income-tax/income/disposals/residential-property/ppd/$nino/${taxYear.asMtd}")
       }

--- a/app/v2/residentialPropertyDisposals/createAmendNonPpd/CreateAmendCgtResidentialPropertyDisposalsConnector.scala
+++ b/app/v2/residentialPropertyDisposals/createAmendNonPpd/CreateAmendCgtResidentialPropertyDisposalsConnector.scala
@@ -17,7 +17,7 @@
 package v2.residentialPropertyDisposals.createAmendNonPpd
 
 import shared.config.SharedAppConfig
-import shared.connectors.DownstreamUri.{IfsUri, TaxYearSpecificIfsUri}
+import shared.connectors.DownstreamUri.IfsUri
 import shared.connectors.{BaseDownstreamConnector, DownstreamOutcome}
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.http.client.HttpClientV2
@@ -39,7 +39,7 @@ class CreateAmendCgtResidentialPropertyDisposalsConnector @Inject() (val http: H
     import shared.connectors.httpparsers.StandardDownstreamHttpParser._
 
     val uri = if (taxYear.useTaxYearSpecificApi) {
-      TaxYearSpecificIfsUri[Unit](s"income-tax/income/disposals/residential-property/${taxYear.asTysDownstream}/${nino.nino}")
+      IfsUri[Unit](s"income-tax/income/disposals/residential-property/${taxYear.asTysDownstream}/${nino.nino}")
     } else {
       // Pre-tys uses MTD tax year format
       IfsUri[Unit](s"income-tax/income/disposals/residential-property/${nino.nino}/${taxYear.asMtd}")

--- a/app/v2/residentialPropertyDisposals/deleteCgtPpdOverrides/DeleteCgtPpdOverridesConnector.scala
+++ b/app/v2/residentialPropertyDisposals/deleteCgtPpdOverrides/DeleteCgtPpdOverridesConnector.scala
@@ -17,7 +17,7 @@
 package v2.residentialPropertyDisposals.deleteCgtPpdOverrides
 
 import shared.config.SharedAppConfig
-import shared.connectors.DownstreamUri.{DesUri, TaxYearSpecificIfsUri}
+import shared.connectors.DownstreamUri.{DesUri, IfsUri}
 import shared.connectors.{BaseDownstreamConnector, DownstreamOutcome}
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.http.client.HttpClientV2
@@ -39,7 +39,7 @@ class DeleteCgtPpdOverridesConnector @Inject() (val http: HttpClientV2, val appC
     import request._
 
     val downstreamUri = if (taxYear.useTaxYearSpecificApi) {
-      TaxYearSpecificIfsUri[Unit](s"income-tax/income/disposals/residential-property/ppd/${taxYear.asTysDownstream}/${nino.nino}")
+      IfsUri[Unit](s"income-tax/income/disposals/residential-property/ppd/${taxYear.asTysDownstream}/${nino.nino}")
     } else {
       DesUri[Unit](s"income-tax/income/disposals/residential-property/ppd/${nino.nino}/${taxYear.asMtd}")
     }

--- a/app/v2/residentialPropertyDisposals/deleteNonPpd/DeleteCgtNonPpdConnector.scala
+++ b/app/v2/residentialPropertyDisposals/deleteNonPpd/DeleteCgtNonPpdConnector.scala
@@ -17,7 +17,7 @@
 package v2.residentialPropertyDisposals.deleteNonPpd
 
 import shared.config.SharedAppConfig
-import shared.connectors.DownstreamUri.{IfsUri, TaxYearSpecificIfsUri}
+import shared.connectors.DownstreamUri.IfsUri
 import shared.connectors.httpparsers.StandardDownstreamHttpParser._
 import shared.connectors.{BaseDownstreamConnector, DownstreamOutcome}
 import uk.gov.hmrc.http.HeaderCarrier
@@ -38,7 +38,7 @@ class DeleteCgtNonPpdConnector @Inject() (val http: HttpClientV2, val appConfig:
     import request._
 
     val downstreamUri = if (taxYear.useTaxYearSpecificApi) {
-      TaxYearSpecificIfsUri[Unit](s"income-tax/income/disposals/residential-property/${taxYear.asTysDownstream}/${nino.value}")
+      IfsUri[Unit](s"income-tax/income/disposals/residential-property/${taxYear.asTysDownstream}/${nino.value}")
     } else {
       // Note: tax year is in MTD format
       IfsUri[Unit](s"income-tax/income/disposals/residential-property/${nino.value}/${taxYear.asMtd}")

--- a/app/v2/residentialPropertyDisposals/retrieveAll/RetrieveAllResidentialPropertyCgtConnector.scala
+++ b/app/v2/residentialPropertyDisposals/retrieveAll/RetrieveAllResidentialPropertyCgtConnector.scala
@@ -17,7 +17,7 @@
 package v2.residentialPropertyDisposals.retrieveAll
 
 import shared.config.SharedAppConfig
-import shared.connectors.DownstreamUri.{DesUri, TaxYearSpecificIfsUri}
+import shared.connectors.DownstreamUri.{DesUri, IfsUri}
 import shared.connectors.{BaseDownstreamConnector, DownstreamOutcome, DownstreamUri}
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.http.client.HttpClientV2
@@ -46,7 +46,7 @@ class RetrieveAllResidentialPropertyCgtConnector @Inject() (val http: HttpClient
 
     val downstreamUri: DownstreamUri[DownstreamResp] = taxYear match {
       case ty if ty.useTaxYearSpecificApi =>
-        TaxYearSpecificIfsUri(s"income-tax/income/disposals/residential-property/${taxYear.asTysDownstream}/${nino.value}")
+        IfsUri(s"income-tax/income/disposals/residential-property/${taxYear.asTysDownstream}/${nino.value}")
       case _ =>
         DesUri(s"income-tax/income/disposals/residential-property/${nino.value}/${taxYear.asMtd}")
     }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -177,14 +177,6 @@ microservice {
       environmentHeaders = ["Accept", "Gov-Test-Scenario", "Content-Type", "Location", "X-Request-Timestamp", "X-Session-Id", "X-Request-Id"]
     }
 
-    tys-ifs {
-      host = 127.0.0.1
-      port = 9772
-      env = Prod
-      token = ABCD1234
-      environmentHeaders = ["Accept", "Gov-Test-Scenario", "Content-Type", "Location", "X-Request-Timestamp", "X-Session-Id", "X-Request-Id"]
-    }
-
     api1661 {
       host = 127.0.0.1
       port = 9772

--- a/it/test/shared/support/IntegrationBaseSpec.scala
+++ b/it/test/shared/support/IntegrationBaseSpec.scala
@@ -35,8 +35,6 @@ trait IntegrationBaseSpec extends UnitSpec with WireMockHelper with GuiceOneServ
     "microservice.services.des.port"               -> mockPort,
     "microservice.services.ifs.host"               -> mockHost,
     "microservice.services.ifs.port"               -> mockPort,
-    "microservice.services.tys-ifs.host"           -> mockHost,
-    "microservice.services.tys-ifs.port"           -> mockPort,
     "microservice.services.hip.host"               -> mockHost,
     "microservice.services.hip.port"               -> mockPort,
     "microservice.services.mtd-id-lookup.host"     -> mockHost,

--- a/test/shared/config/MockSharedAppConfig.scala
+++ b/test/shared/config/MockSharedAppConfig.scala
@@ -33,7 +33,6 @@ trait MockSharedAppConfig extends TestSuite with MockFactory {
 
     def desDownstreamConfig: CallHandler0[DownstreamConfig]    = (() => mockSharedAppConfig.desDownstreamConfig: DownstreamConfig).expects()
     def ifsDownstreamConfig: CallHandler0[DownstreamConfig]    = (() => mockSharedAppConfig.ifsDownstreamConfig: DownstreamConfig).expects()
-    def tysIfsDownstreamConfig: CallHandler0[DownstreamConfig] = (() => mockSharedAppConfig.tysIfsDownstreamConfig: DownstreamConfig).expects()
 
     def hipDownstreamConfig: CallHandler[BasicAuthDownstreamConfig] =
       (() => mockSharedAppConfig.hipDownstreamConfig: BasicAuthDownstreamConfig).expects()

--- a/test/shared/config/SharedAppConfigSpec.scala
+++ b/test/shared/config/SharedAppConfigSpec.scala
@@ -74,22 +74,6 @@ class SharedAppConfigSpec extends UnitSpec {
       )
     }
 
-    "return the TYS-IFS config" in {
-      val expectedTysIfsEnvHeaders = Some(
-        List(
-          "TYS-IFS-Accept",
-          "TYS-IFS-Gov-Test-Scenario",
-          "TYS-IFS-Content-Type"
-        ))
-
-      simpleAppConfig.tysIfsDownstreamConfig shouldBe DownstreamConfig(
-        "http://127.0.0.1:8888",
-        "Prod",
-        "TYS-IFS-ABCD1234",
-        expectedTysIfsEnvHeaders
-      )
-    }
-
     "return the apiDocumentationUrl" when {
       "it is not specified" in {
         val changedAppConfig = appConfig("", None)
@@ -361,14 +345,6 @@ class SharedAppConfigSpec extends UnitSpec {
            |        env = Prod
            |        token = IFS-ABCD1234
            |        environmentHeaders = ["IFS-Accept", "IFS-Gov-Test-Scenario", "IFS-Content-Type"]
-           |      }
-           |
-           |      tys-ifs {
-           |        host = 127.0.0.1
-           |        port = 8888
-           |        env = Prod
-           |        token = TYS-IFS-ABCD1234
-           |        environmentHeaders = ["TYS-IFS-Accept", "TYS-IFS-Gov-Test-Scenario", "TYS-IFS-Content-Type"]
            |      }
            |    }
            |  }

--- a/test/shared/config/rewriters/EndpointSummaryRewriterSpec.scala
+++ b/test/shared/config/rewriters/EndpointSummaryRewriterSpec.scala
@@ -44,7 +44,7 @@ class EndpointSummaryRewriterSpec extends UnitSpec with MockSharedAppConfig {
 
     "the summary already contains [test only]" should {
       "return the summary unchanged" in {
-        val summary = """summary: "[tesT oNLy] Create and Amend employment expenses""""
+        val summary = """summary: "[tesT oNLy] Create and Amend CGT Residential Property Disposals""""
         val result  = rewrite("", "", summary)
         result shouldBe summary
       }
@@ -52,13 +52,13 @@ class EndpointSummaryRewriterSpec extends UnitSpec with MockSharedAppConfig {
 
     "the yaml summary is ready to be rewritten" should {
       "return the rewritten summary, in quotes due to the '[' special character" in {
-        val result = rewrite("", "", "summary: Create and Amend employment expenses")
-        result shouldBe """summary: "Create and Amend employment expenses [test only]""""
+        val result = rewrite("", "", "summary: Create and Amend CGT Residential Property Disposals")
+        result shouldBe """summary: "Create and Amend CGT Residential Property Disposals [test only]""""
       }
 
       "return the rewritten summary preserving indentation" in {
-        val result = rewrite("", "", "  summary: Create and Amend employment expenses")
-        result shouldBe """  summary: "Create and Amend employment expenses [test only]""""
+        val result = rewrite("", "", "  summary: Create and Amend CGT Residential Property Disposals")
+        result shouldBe """  summary: "Create and Amend CGT Residential Property Disposals [test only]""""
       }
 
       "return the rewritten summary when it contains parentheses" in {
@@ -74,16 +74,16 @@ class EndpointSummaryRewriterSpec extends UnitSpec with MockSharedAppConfig {
 
     "the yaml summary is already in quotes" should {
       "return the rewritten summary" in {
-        val result = rewrite("", "", """summary: "Create and Amend employment expenses"""")
-        result shouldBe """summary: "Create and Amend employment expenses [test only]""""
+        val result = rewrite("", "", """summary: "Create and Amend CGT Residential Property Disposals"""")
+        result shouldBe """summary: "Create and Amend CGT Residential Property Disposals [test only]""""
       }
     }
 
     "the yaml is not for a single endpoint" should {
       "return the yaml unchanged" in {
         val yaml = """
-                     |summary: "Create and Amend employment expenses"
-                     |summary: "Create and Amend employment expenses"""".stripMargin
+                     |summary: "Create and Amend CGT Residential Property Disposals"
+                     |summary: "Create and Amend CGT Residential Property Disposals"""".stripMargin
         val result = rewrite("", "", yaml)
         result shouldBe yaml
 

--- a/test/shared/connectors/ConnectorSpec.scala
+++ b/test/shared/connectors/ConnectorSpec.scala
@@ -132,12 +132,6 @@ trait ConnectorSpec extends UnitSpec with Status with MimeTypes with HeaderNames
     MockedSharedAppConfig.ifsDownstreamConfig.anyNumberOfTimes() returns config
   }
 
-  protected trait TysIfsTest extends StandardConnectorTest {
-    override val name = "tys-ifs"
-
-    MockedSharedAppConfig.tysIfsDownstreamConfig.anyNumberOfTimes() returns config
-  }
-
   protected trait HipTest extends ConnectorTest {
     private val clientId     = "clientId"
     private val clientSecret = "clientSecret"

--- a/test/v1/otherCgt/createAmend/CreateAmendOtherCgtConnectorSpec.scala
+++ b/test/v1/otherCgt/createAmend/CreateAmendOtherCgtConnectorSpec.scala
@@ -70,7 +70,7 @@ class CreateAmendOtherCgtConnectorSpec extends ConnectorSpec with MockAppConfig 
         await(connector.createAndAmend(createAmendOtherCgtRequestData)) shouldBe outcome
       }
 
-      "a valid request is made with Tax Year Specific tax year" in new TysIfsTest with Test {
+      "a valid request is made with Tax Year Specific tax year" in new IfsTest with Test {
 
         override val taxYear: TaxYear = TaxYear.fromMtd("2023-24")
         val createAmendOtherCgtRequestData: CreateAmendOtherCgtRequestData = Def1_CreateAmendOtherCgtRequestData(

--- a/test/v1/otherCgt/delete/DeleteOtherCgtConnectorSpec.scala
+++ b/test/v1/otherCgt/delete/DeleteOtherCgtConnectorSpec.scala
@@ -24,6 +24,7 @@ import v1.otherCgt.delete.def1.model.request.Def1_DeleteOtherCgtRequestData
 import v1.otherCgt.delete.model.request.DeleteOtherCgtRequestData
 
 import scala.concurrent.Future
+
 class DeleteOtherCgtConnectorSpec extends CgtConnectorSpec {
 
   "DeleteOtherCgtConnector" should {
@@ -40,7 +41,7 @@ class DeleteOtherCgtConnectorSpec extends CgtConnectorSpec {
       }
     }
     "return the expected response for a TYS request" when {
-      "a valid request is made" in new TysIfsTest with Test {
+      "a valid request is made" in new IfsTest with Test {
         def taxYear: TaxYear = TaxYear.fromMtd("2023-24")
         val outcome          = Right(ResponseWrapper(correlationId, ()))
 

--- a/test/v1/otherCgt/retrieve/RetrieveOtherCgtConnectorSpec.scala
+++ b/test/v1/otherCgt/retrieve/RetrieveOtherCgtConnectorSpec.scala
@@ -43,7 +43,7 @@ class RetrieveOtherCgtConnectorSpec extends CgtConnectorSpec {
       }
     }
     "return the expected response for a TYS request" when {
-      "a valid request is made" in new TysIfsTest with Test {
+      "a valid request is made" in new IfsTest with Test {
         def taxYear: TaxYear = TaxYear.fromMtd("2023-24")
         val outcome          = Right(ResponseWrapper(correlationId, response))
 

--- a/test/v1/residentialPropertyDisposals/createAmendCgtPpdOverrides/CreateAmendCgtPpdOverridesConnectorSpec.scala
+++ b/test/v1/residentialPropertyDisposals/createAmendCgtPpdOverrides/CreateAmendCgtPpdOverridesConnectorSpec.scala
@@ -66,7 +66,7 @@ class CreateAmendCgtPpdOverridesConnectorSpec extends CgtConnectorSpec {
 
     "createAndAmend called for a Tax Year Specific tax year" must {
       "return a 200 status for a success scenario" in
-        new TysIfsTest with Test {
+        new IfsTest with Test {
           def taxYear: TaxYear = TaxYear.fromMtd("2023-24")
 
           implicit val hc: HeaderCarrier = HeaderCarrier(otherHeaders = otherHeaders ++ Seq("Content-Type" -> "application/json"))

--- a/test/v1/residentialPropertyDisposals/createAmendNonPpd/CreateAmendCgtResidentialPropertyDisposalsConnectorSpec.scala
+++ b/test/v1/residentialPropertyDisposals/createAmendNonPpd/CreateAmendCgtResidentialPropertyDisposalsConnectorSpec.scala
@@ -63,7 +63,7 @@ class CreateAmendCgtResidentialPropertyDisposalsConnectorSpec extends CgtConnect
         await(connector.createAndAmend(createAmendCgtResidentialPropertyDisposalsRequest)) shouldBe outcome
       }
 
-      "a valid request is made for a TYS tax year" in new TysIfsTest with Test {
+      "a valid request is made for a TYS tax year" in new IfsTest with Test {
         lazy val taxYear = TaxYear.fromMtd("2023-24")
 
         val outcome = Right(ResponseWrapper(correlationId, ()))

--- a/test/v1/residentialPropertyDisposals/deleteCgtPpdOverrides/DeleteCgtPpdOverridesConnectorSpec.scala
+++ b/test/v1/residentialPropertyDisposals/deleteCgtPpdOverrides/DeleteCgtPpdOverridesConnectorSpec.scala
@@ -15,13 +15,14 @@
  */
 
 package v1.residentialPropertyDisposals.deleteCgtPpdOverrides
+
 import shared.connectors.ConnectorSpec
 import shared.models.domain.{Nino, TaxYear}
 import shared.models.errors.{InternalError, NinoFormatError}
 import shared.models.outcomes.ResponseWrapper
+import uk.gov.hmrc.http.StringContextOps
 import v1.residentialPropertyDisposals.deleteCgtPpdOverrides.def1.model.request.Def1_DeleteCgtPpdOverridesRequestData
 import v1.residentialPropertyDisposals.deleteCgtPpdOverrides.model.request.DeleteCgtPpdOverridesRequestData
-import uk.gov.hmrc.http.StringContextOps
 
 import scala.concurrent.Future
 
@@ -84,7 +85,7 @@ class DeleteCgtPpdOverridesConnectorSpec extends ConnectorSpec {
 
     }
     "return the expected response for a TYS request" when {
-      "a valid request is made" in new TysIfsTest with Test {
+      "a valid request is made" in new IfsTest with Test {
         def taxYear: TaxYear = TaxYear.fromMtd("2023-24")
 
         val outcome = Right(ResponseWrapper(correlationId, ()))

--- a/test/v1/residentialPropertyDisposals/deleteNonPpd/DeleteCgtNonPpdConnectorSpec.scala
+++ b/test/v1/residentialPropertyDisposals/deleteNonPpd/DeleteCgtNonPpdConnectorSpec.scala
@@ -45,7 +45,7 @@ class DeleteCgtNonPpdConnectorSpec extends CgtConnectorSpec {
     }
 
     "deleteCgtNonPpd is called for a TaxYearSpecific tax year" must {
-      "return a 200 for success scenario" in new TysIfsTest with Test {
+      "return a 200 for success scenario" in new IfsTest with Test {
         def taxYear: TaxYear = TaxYear.fromMtd("2023-24")
 
         val outcome = Right(ResponseWrapper(correlationId, ()))

--- a/test/v1/residentialPropertyDisposals/retrieveAll/RetrieveAllResidentialPropertyCgtConnectorSpec.scala
+++ b/test/v1/residentialPropertyDisposals/retrieveAll/RetrieveAllResidentialPropertyCgtConnectorSpec.scala
@@ -84,7 +84,7 @@ class RetrieveAllResidentialPropertyCgtConnectorSpec extends ConnectorSpec {
     }
 
     "retrieveAllResidentialPropertyCgt for Tax Year Specific (TYS)" must {
-      "return a 200 status for a success scenario" in new TysIfsTest with Test {
+      "return a 200 status for a success scenario" in new IfsTest with Test {
         override def taxYear: TaxYear = TaxYear.fromMtd("2023-24")
 
         val outcome = Right(ResponseWrapper(correlationId, response))

--- a/test/v2/otherCgt/createAmend/CreateAmendOtherCgtConnectorSpec.scala
+++ b/test/v2/otherCgt/createAmend/CreateAmendOtherCgtConnectorSpec.scala
@@ -30,6 +30,7 @@ import scala.concurrent.Future
 class CreateAmendOtherCgtConnectorSpec extends ConnectorSpec with MockAppConfig {
 
   private val nino: String = "AA111111A"
+
   val allowedIfsHeaders: Seq[String] = List(
     "Accept",
     "Gov-Test-Scenario",
@@ -38,6 +39,7 @@ class CreateAmendOtherCgtConnectorSpec extends ConnectorSpec with MockAppConfig 
     "X-Request-Timestamp",
     "X-Session-Id"
   )
+
   trait Test { _: ConnectorTest =>
     def taxYear: TaxYear
 
@@ -50,7 +52,7 @@ class CreateAmendOtherCgtConnectorSpec extends ConnectorSpec with MockAppConfig 
 
   "createAndAmend" should {
     "return a 204 status" when {
-      "a valid request is made" in new IfsTest  with Test {
+      "a valid request is made" in new IfsTest with Test {
 
         override val taxYear: TaxYear = TaxYear.fromMtd("2019-20")
 
@@ -70,7 +72,7 @@ class CreateAmendOtherCgtConnectorSpec extends ConnectorSpec with MockAppConfig 
         await(connector.createAndAmend(createAmendOtherCgtRequestData)) shouldBe outcome
       }
 
-      "a valid request is made with Tax Year Specific tax year" in new TysIfsTest with Test {
+      "a valid request is made with Tax Year Specific tax year" in new IfsTest with Test {
 
         override val taxYear: TaxYear = TaxYear.fromMtd("2023-24")
         val createAmendOtherCgtRequestData: CreateAmendOtherCgtRequestData = Def1_CreateAmendOtherCgtRequestData(

--- a/test/v2/otherCgt/delete/DeleteOtherCgtConnectorSpec.scala
+++ b/test/v2/otherCgt/delete/DeleteOtherCgtConnectorSpec.scala
@@ -24,6 +24,7 @@ import v2.otherCgt.delete.def1.model.request.Def1_DeleteOtherCgtRequestData
 import v2.otherCgt.delete.model.request.DeleteOtherCgtRequestData
 
 import scala.concurrent.Future
+
 class DeleteOtherCgtConnectorSpec extends CgtConnectorSpec {
 
   "DeleteOtherCgtConnector" should {
@@ -40,7 +41,7 @@ class DeleteOtherCgtConnectorSpec extends CgtConnectorSpec {
       }
     }
     "return the expected response for a TYS request" when {
-      "a valid request is made" in new TysIfsTest with Test {
+      "a valid request is made" in new IfsTest with Test {
         def taxYear: TaxYear = TaxYear.fromMtd("2023-24")
         val outcome          = Right(ResponseWrapper(correlationId, ()))
 

--- a/test/v2/otherCgt/retrieve/RetrieveOtherCgtConnectorSpec.scala
+++ b/test/v2/otherCgt/retrieve/RetrieveOtherCgtConnectorSpec.scala
@@ -43,7 +43,7 @@ class RetrieveOtherCgtConnectorSpec extends CgtConnectorSpec {
       }
     }
     "return the expected response for a TYS request" when {
-      "a valid request is made" in new TysIfsTest with Test {
+      "a valid request is made" in new IfsTest with Test {
         def taxYear: TaxYear = TaxYear.fromMtd("2023-24")
         val outcome          = Right(ResponseWrapper(correlationId, response))
 

--- a/test/v2/residentialPropertyDisposals/createAmendCgtPpdOverrides/CreateAmendCgtPpdOverridesConnectorSpec.scala
+++ b/test/v2/residentialPropertyDisposals/createAmendCgtPpdOverrides/CreateAmendCgtPpdOverridesConnectorSpec.scala
@@ -66,7 +66,7 @@ class CreateAmendCgtPpdOverridesConnectorSpec extends CgtConnectorSpec {
 
     "createAndAmend called for a Tax Year Specific tax year" must {
       "return a 200 status for a success scenario" in
-        new TysIfsTest with Test {
+        new IfsTest with Test {
           def taxYear: TaxYear = TaxYear.fromMtd("2023-24")
 
           implicit val hc: HeaderCarrier = HeaderCarrier(otherHeaders = otherHeaders ++ Seq("Content-Type" -> "application/json"))

--- a/test/v2/residentialPropertyDisposals/createAmendNonPpd/CreateAmendCgtResidentialPropertyDisposalsConnectorSpec.scala
+++ b/test/v2/residentialPropertyDisposals/createAmendNonPpd/CreateAmendCgtResidentialPropertyDisposalsConnectorSpec.scala
@@ -63,7 +63,7 @@ class CreateAmendCgtResidentialPropertyDisposalsConnectorSpec extends CgtConnect
         await(connector.createAndAmend(createAmendCgtResidentialPropertyDisposalsRequest)) shouldBe outcome
       }
 
-      "a valid request is made for a TYS tax year" in new TysIfsTest with Test {
+      "a valid request is made for a TYS tax year" in new IfsTest with Test {
         lazy val taxYear: TaxYear = TaxYear.fromMtd("2023-24")
 
         val outcome = Right(ResponseWrapper(correlationId, ()))

--- a/test/v2/residentialPropertyDisposals/deleteCgtPpdOverrides/DeleteCgtPpdOverridesConnectorSpec.scala
+++ b/test/v2/residentialPropertyDisposals/deleteCgtPpdOverrides/DeleteCgtPpdOverridesConnectorSpec.scala
@@ -85,7 +85,7 @@ class DeleteCgtPpdOverridesConnectorSpec extends ConnectorSpec {
 
     }
     "return the expected response for a TYS request" when {
-      "a valid request is made" in new TysIfsTest with Test {
+      "a valid request is made" in new IfsTest with Test {
         def taxYear: TaxYear = TaxYear.fromMtd("2023-24")
 
         val outcome = Right(ResponseWrapper(correlationId, ()))

--- a/test/v2/residentialPropertyDisposals/deleteNonPpd/DeleteCgtNonPpdConnectorSpec.scala
+++ b/test/v2/residentialPropertyDisposals/deleteNonPpd/DeleteCgtNonPpdConnectorSpec.scala
@@ -45,7 +45,7 @@ class DeleteCgtNonPpdConnectorSpec extends CgtConnectorSpec {
     }
 
     "deleteCgtNonPpd is called for a TaxYearSpecific tax year" must {
-      "return a 200 for success scenario" in new TysIfsTest with Test {
+      "return a 200 for success scenario" in new IfsTest with Test {
         def taxYear: TaxYear = TaxYear.fromMtd("2023-24")
 
         val outcome = Right(ResponseWrapper(correlationId, ()))

--- a/test/v2/residentialPropertyDisposals/retrieveAll/RetrieveAllResidentialPropertyCgtConnectorSpec.scala
+++ b/test/v2/residentialPropertyDisposals/retrieveAll/RetrieveAllResidentialPropertyCgtConnectorSpec.scala
@@ -84,7 +84,7 @@ class RetrieveAllResidentialPropertyCgtConnectorSpec extends ConnectorSpec {
     }
 
     "retrieveAllResidentialPropertyCgt for Tax Year Specific (TYS)" must {
-      "return a 200 status for a success scenario" in new TysIfsTest with Test {
+      "return a 200 status for a success scenario" in new IfsTest with Test {
         override def taxYear: TaxYear = TaxYear.fromMtd("2023-24")
 
         val outcome = Right(ResponseWrapper(correlationId, response))


### PR DESCRIPTION
Config PR's to make subsequent changes to all environment config files

1. [https://github.com/hmrc/app-config-development/pull/9765](https://github.com/hmrc/app-config-development/pull/9765)
2. [https://github.com/hmrc/app-config-qa/pull/25797](https://github.com/hmrc/app-config-qa/pull/25797)
3. [https://github.com/hmrc/app-config-staging/pull/17751](https://github.com/hmrc/app-config-staging/pull/17751)
4. [https://github.com/hmrc/app-config-externaltest/pull/5650](https://github.com/hmrc/app-config-externaltest/pull/5650)
5. [https://github.com/hmrc/app-config-base/pull/12299](https://github.com/hmrc/app-config-base/pull/12299)
6. [https://github.com/hmrc/app-config-production/pull/25927](https://github.com/hmrc/app-config-production/pull/25927)