### PR TITLE
IFS to HIP Migration

### DIFF
--- a/app/v1/otherCgt/createAmend/def1/Def1_CreateAmendOtherCgtValidator.scala
+++ b/app/v1/otherCgt/createAmend/def1/Def1_CreateAmendOtherCgtValidator.scala
@@ -21,9 +21,9 @@ import cats.implicits.*
 import config.CgtAppConfig
 import play.api.libs.json.JsValue
 import shared.controllers.validators.Validator
-import shared.controllers.validators.resolvers.{ResolveNino, ResolveNonEmptyJsonObject, ResolveTaxYearMinimum}
+import shared.controllers.validators.resolvers.{ResolveNino, ResolveNonEmptyJsonObject, ResolveTaxYearMinMax}
 import shared.models.domain.TaxYear
-import shared.models.errors.MtdError
+import shared.models.errors.{MtdError, RuleTaxYearForVersionNotSupportedError, RuleTaxYearNotSupportedError}
 import v1.otherCgt.createAmend.def1.Def1_CreateAmendOtherCgtRulesValidator.validateBusinessRules
 import v1.otherCgt.createAmend.def1.model.request.{Def1_CreateAmendOtherCgtRequestBody, Def1_CreateAmendOtherCgtRequestData}
 import v1.otherCgt.createAmend.model.request.CreateAmendOtherCgtRequestData
@@ -32,8 +32,13 @@ class Def1_CreateAmendOtherCgtValidator(nino: String, taxYear: String, body: JsV
     extends Validator[CreateAmendOtherCgtRequestData] {
 
   private lazy val minimumTaxYear = appConfig.minimumPermittedTaxYear
-  private lazy val resolveTaxYear = ResolveTaxYearMinimum(TaxYear.fromDownstreamInt(minimumTaxYear))
-  private lazy val resolveJson    = new ResolveNonEmptyJsonObject[Def1_CreateAmendOtherCgtRequestBody]()
+
+  private lazy val resolveTaxYear = ResolveTaxYearMinMax(
+    (TaxYear.fromDownstreamInt(minimumTaxYear), TaxYear.fromMtd("2024-25")),
+    RuleTaxYearNotSupportedError,
+    RuleTaxYearForVersionNotSupportedError)
+
+  private lazy val resolveJson = new ResolveNonEmptyJsonObject[Def1_CreateAmendOtherCgtRequestBody]()
 
   def validate: Validated[Seq[MtdError], CreateAmendOtherCgtRequestData] =
     (

--- a/app/v1/otherCgt/delete/DeleteOtherCgtConnector.scala
+++ b/app/v1/otherCgt/delete/DeleteOtherCgtConnector.scala
@@ -16,8 +16,8 @@
 
 package v1.otherCgt.delete
 
-import shared.config.SharedAppConfig
-import shared.connectors.DownstreamUri.IfsUri
+import shared.config.{ConfigFeatureSwitches, SharedAppConfig}
+import shared.connectors.DownstreamUri.{HipUri, IfsUri}
 import shared.connectors.{BaseDownstreamConnector, DownstreamOutcome}
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.http.client.HttpClientV2
@@ -38,15 +38,15 @@ class DeleteOtherCgtConnector @Inject() (val http: HttpClientV2, val appConfig: 
 
     import request.*
 
-    val downstreamUri = if (taxYear.useTaxYearSpecificApi) {
-      IfsUri[Unit](
-        s"income-tax/income/disposals/other-gains/${taxYear.asTysDownstream}/${nino.value}"
-      )
+    lazy val downstreamUri1741 = IfsUri[Unit](s"income-tax/income/disposals/other-gains/${nino.value}/${taxYear.asMtd}")
+
+    lazy val downstreamUri1953 = if (ConfigFeatureSwitches().isEnabled("ifs_hip_migration_1953")) {
+      HipUri[Unit](s"itsa/income-tax/v1/${taxYear.asTysDownstream}/income/disposals/other-gains/${nino.value}")
     } else {
-      IfsUri[Unit](
-        s"income-tax/income/disposals/other-gains/${nino.value}/${taxYear.asMtd}"
-      )
+      IfsUri[Unit](s"income-tax/income/disposals/other-gains/${taxYear.asTysDownstream}/${nino.value}")
     }
+    
+    val downstreamUri = if (taxYear.useTaxYearSpecificApi) downstreamUri1953 else downstreamUri1741
 
     delete(uri = downstreamUri)
 

--- a/app/v1/otherCgt/delete/def1/Def1_DeleteOtherCgtValidator.scala
+++ b/app/v1/otherCgt/delete/def1/Def1_DeleteOtherCgtValidator.scala
@@ -20,9 +20,9 @@ import cats.data.Validated
 import cats.implicits.*
 import config.CgtAppConfig
 import shared.controllers.validators.Validator
-import shared.controllers.validators.resolvers.{ResolveNino, ResolveTaxYearMinimum}
+import shared.controllers.validators.resolvers.{ResolveNino, ResolveTaxYearMinMax}
 import shared.models.domain.TaxYear
-import shared.models.errors.MtdError
+import shared.models.errors.{MtdError, RuleTaxYearForVersionNotSupportedError, RuleTaxYearNotSupportedError}
 import v1.otherCgt.delete.def1.model.request.Def1_DeleteOtherCgtRequestData
 import v1.otherCgt.delete.model.request.DeleteOtherCgtRequestData
 
@@ -31,7 +31,11 @@ import javax.inject.Inject
 class Def1_DeleteOtherCgtValidator @Inject() (nino: String, taxYear: String)(appConfig: CgtAppConfig) extends Validator[DeleteOtherCgtRequestData] {
 
   private lazy val minimumTaxYear = appConfig.minimumPermittedTaxYear
-  private lazy val resolveTaxYear = ResolveTaxYearMinimum(TaxYear.fromDownstreamInt(minimumTaxYear))
+
+  private lazy val resolveTaxYear = ResolveTaxYearMinMax(
+    (TaxYear.fromDownstreamInt(minimumTaxYear), TaxYear.fromMtd("2024-25")),
+    RuleTaxYearNotSupportedError,
+    RuleTaxYearForVersionNotSupportedError)
 
   def validate: Validated[Seq[MtdError], DeleteOtherCgtRequestData] =
     (

--- a/app/v1/otherCgt/retrieve/RetrieveOtherCgtConnector.scala
+++ b/app/v1/otherCgt/retrieve/RetrieveOtherCgtConnector.scala
@@ -16,8 +16,8 @@
 
 package v1.otherCgt.retrieve
 
-import shared.config.SharedAppConfig
-import shared.connectors.DownstreamUri.IfsUri
+import shared.config.{ConfigFeatureSwitches, SharedAppConfig}
+import shared.connectors.DownstreamUri.{HipUri, IfsUri}
 import shared.connectors.{BaseDownstreamConnector, DownstreamOutcome, DownstreamUri}
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.http.client.HttpClientV2
@@ -40,14 +40,19 @@ class RetrieveOtherCgtConnector @Inject() (val http: HttpClientV2, val appConfig
     import request.*
     import schema.*
 
-    val downstreamUri: DownstreamUri[DownstreamResp] = taxYear match {
-      case ty if ty.useTaxYearSpecificApi =>
-        IfsUri(s"income-tax/income/disposals/other-gains/${taxYear.asTysDownstream}/${nino.value}")
-      case _ =>
-        IfsUri(s"income-tax/income/disposals/other-gains/${nino.value}/${taxYear.asMtd}")
+    lazy val downstreamUri1951: DownstreamUri[DownstreamResp] = if (ConfigFeatureSwitches().isEnabled("ifs_hip_migration_1951")) {
+      HipUri(s"itsa/income-tax/v1/${taxYear.asTysDownstream}/income/disposals/other-gains/${nino.value}")
+    } else {
+      IfsUri(s"income-tax/income/disposals/other-gains/${taxYear.asTysDownstream}/${nino.value}")
     }
 
-    get(uri = downstreamUri)
+    lazy val downstreamUri1737: DownstreamUri[DownstreamResp] = IfsUri(s"income-tax/income/disposals/other-gains/${nino.value}/${taxYear.asMtd}")
+
+    if (taxYear.useTaxYearSpecificApi) {
+      get(uri = downstreamUri1951)
+    } else {
+      get(uri = downstreamUri1737)
+    }
 
   }
 

--- a/app/v1/otherCgt/retrieve/def1/Def1_RetrieveOtherCgtValidator.scala
+++ b/app/v1/otherCgt/retrieve/def1/Def1_RetrieveOtherCgtValidator.scala
@@ -20,9 +20,9 @@ import cats.data.Validated
 import cats.implicits.*
 import config.CgtAppConfig
 import shared.controllers.validators.Validator
-import shared.controllers.validators.resolvers.{ResolveNino, ResolveTaxYearMinimum}
+import shared.controllers.validators.resolvers.{ResolveNino, ResolveTaxYearMinMax}
 import shared.models.domain.TaxYear
-import shared.models.errors.MtdError
+import shared.models.errors.{MtdError, RuleTaxYearForVersionNotSupportedError, RuleTaxYearNotSupportedError}
 import v1.otherCgt.retrieve.def1.model.request.Def1_RetrieveOtherCgtRequestData
 import v1.otherCgt.retrieve.model.request.RetrieveOtherCgtRequestData
 
@@ -33,7 +33,11 @@ class Def1_RetrieveOtherCgtValidator @Inject() (nino: String, taxYear: String)(a
     extends Validator[RetrieveOtherCgtRequestData] {
 
   private lazy val minimumTaxYear = appConfig.minimumPermittedTaxYear
-  private lazy val resolveTaxYear = ResolveTaxYearMinimum(TaxYear.fromDownstreamInt(minimumTaxYear))
+
+  private lazy val resolveTaxYear = ResolveTaxYearMinMax(
+    (TaxYear.fromDownstreamInt(minimumTaxYear), TaxYear.fromMtd("2024-25")),
+    RuleTaxYearNotSupportedError,
+    RuleTaxYearForVersionNotSupportedError)
 
   def validate: Validated[Seq[MtdError], Def1_RetrieveOtherCgtRequestData] =
     (

--- a/app/v1/residentialPropertyDisposals/createAmendNonPpd/CreateAmendCgtResidentialPropertyDisposalsConnector.scala
+++ b/app/v1/residentialPropertyDisposals/createAmendNonPpd/CreateAmendCgtResidentialPropertyDisposalsConnector.scala
@@ -16,9 +16,9 @@
 
 package v1.residentialPropertyDisposals.createAmendNonPpd
 
-import shared.config.SharedAppConfig
-import shared.connectors.DownstreamUri.IfsUri
-import shared.connectors.{BaseDownstreamConnector, DownstreamOutcome}
+import shared.config.{ConfigFeatureSwitches, SharedAppConfig}
+import shared.connectors.DownstreamUri.{HipUri, IfsUri}
+import shared.connectors.{BaseDownstreamConnector, DownstreamOutcome, DownstreamUri}
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.http.client.HttpClientV2
 import v1.residentialPropertyDisposals.createAmendNonPpd.model.request.CreateAmendCgtResidentialPropertyDisposalsRequestData
@@ -38,14 +38,21 @@ class CreateAmendCgtResidentialPropertyDisposalsConnector @Inject() (val http: H
     import request.*
     import shared.connectors.httpparsers.StandardDownstreamHttpParser.*
 
-    val uri = if (taxYear.useTaxYearSpecificApi) {
-      IfsUri[Unit](s"income-tax/income/disposals/residential-property/${taxYear.asTysDownstream}/${nino.nino}")
-    } else {
-      // Pre-tys uses MTD tax year format
-      IfsUri[Unit](s"income-tax/income/disposals/residential-property/${nino.nino}/${taxYear.asMtd}")
-    }
+    lazy val downstreamUri1952: DownstreamUri[Unit] =
+      if (ConfigFeatureSwitches().isEnabled("ifs_hip_migration_1952")) {
+        HipUri(s"itsa/income-tax/v1/${taxYear.asTysDownstream}/income/disposals/residential-property/$nino")
+      } else {
+        IfsUri(s"income-tax/income/disposals/residential-property/${taxYear.asTysDownstream}/${nino.nino}")
+      }
 
-    put(body, uri)
+    lazy val downstreamUri1738: DownstreamUri[Unit] =
+      IfsUri(s"income-tax/income/disposals/residential-property/${nino.nino}/${taxYear.asMtd}")
+
+    val downstreamUri: DownstreamUri[Unit] =
+      if (taxYear.useTaxYearSpecificApi) downstreamUri1952 else downstreamUri1738
+
+    put(body, downstreamUri)
+
   }
 
 }

--- a/app/v1/residentialPropertyDisposals/deleteCgtPpdOverrides/DeleteCgtPpdOverridesConnector.scala
+++ b/app/v1/residentialPropertyDisposals/deleteCgtPpdOverrides/DeleteCgtPpdOverridesConnector.scala
@@ -16,8 +16,8 @@
 
 package v1.residentialPropertyDisposals.deleteCgtPpdOverrides
 
-import shared.config.SharedAppConfig
-import shared.connectors.DownstreamUri.{DesUri, IfsUri}
+import shared.config.{ConfigFeatureSwitches, SharedAppConfig}
+import shared.connectors.DownstreamUri.{HipUri, IfsUri}
 import shared.connectors.{BaseDownstreamConnector, DownstreamOutcome}
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.http.client.HttpClientV2
@@ -38,13 +38,15 @@ class DeleteCgtPpdOverridesConnector @Inject() (val http: HttpClientV2, val appC
 
     import request.*
 
-    val downstreamUri = if (taxYear.useTaxYearSpecificApi) {
-      IfsUri[Unit](s"income-tax/income/disposals/residential-property/ppd/${taxYear.asTysDownstream}/${nino.nino}")
+    lazy val downstreamUri1947 = if (ConfigFeatureSwitches().isEnabled("ifs_hip_migration_1947")) {
+      HipUri(s"itsa/income-tax/v1/${taxYear.asTysDownstream}/income/disposals/residential-property/ppd/${nino.nino}")
     } else {
-      DesUri[Unit](s"income-tax/income/disposals/residential-property/ppd/${nino.nino}/${taxYear.asMtd}")
+      IfsUri[Unit](s"income-tax/income/disposals/residential-property/ppd/${taxYear.asTysDownstream}/${nino.nino}")
     }
 
-    delete(downstreamUri)
+    lazy val downstreamUri1726 = IfsUri[Unit](s"income-tax/income/disposals/residential-property/ppd/${nino.nino}/${taxYear.asMtd}")
+
+    if (taxYear.useTaxYearSpecificApi) delete(downstreamUri1947) else delete(downstreamUri1726)
   }
 
 }

--- a/app/v1/residentialPropertyDisposals/deleteCgtPpdOverrides/def1/Def1_DeleteCgtPpdOverridesValidator.scala
+++ b/app/v1/residentialPropertyDisposals/deleteCgtPpdOverrides/def1/Def1_DeleteCgtPpdOverridesValidator.scala
@@ -20,9 +20,9 @@ import cats.data.Validated
 import cats.implicits.*
 import config.CgtAppConfig
 import shared.controllers.validators.Validator
-import shared.controllers.validators.resolvers.{ResolveNino, ResolveTaxYearMinimum}
+import shared.controllers.validators.resolvers.{ResolveNino, ResolveTaxYearMinMax}
 import shared.models.domain.TaxYear
-import shared.models.errors.MtdError
+import shared.models.errors.{MtdError, RuleTaxYearForVersionNotSupportedError, RuleTaxYearNotSupportedError}
 import v1.residentialPropertyDisposals.deleteCgtPpdOverrides.def1.model.request.Def1_DeleteCgtPpdOverridesRequestData
 import v1.residentialPropertyDisposals.deleteCgtPpdOverrides.model.request.DeleteCgtPpdOverridesRequestData
 
@@ -32,7 +32,12 @@ class Def1_DeleteCgtPpdOverridesValidator @Inject() (nino: String, taxYear: Stri
     extends Validator[DeleteCgtPpdOverridesRequestData] {
 
   private lazy val minimumTaxYear = appConfig.minimumPermittedTaxYear
-  private lazy val resolveTaxYear = ResolveTaxYearMinimum(TaxYear.fromDownstreamInt(minimumTaxYear))
+
+  private lazy val resolveTaxYear =
+    ResolveTaxYearMinMax(
+      (TaxYear.fromDownstreamInt(minimumTaxYear), TaxYear.fromMtd("2024-25")),
+      RuleTaxYearNotSupportedError,
+      RuleTaxYearForVersionNotSupportedError)
 
   def validate: Validated[Seq[MtdError], DeleteCgtPpdOverridesRequestData] =
     (

--- a/app/v1/residentialPropertyDisposals/deleteNonPpd/def1/Def1_DeleteCgtNonPpdValidator.scala
+++ b/app/v1/residentialPropertyDisposals/deleteNonPpd/def1/Def1_DeleteCgtNonPpdValidator.scala
@@ -20,9 +20,9 @@ import cats.data.Validated
 import cats.implicits.*
 import config.CgtAppConfig
 import shared.controllers.validators.Validator
-import shared.controllers.validators.resolvers.{ResolveNino, ResolveTaxYearMinimum}
+import shared.controllers.validators.resolvers.{ResolveNino, ResolveTaxYearMinMax}
 import shared.models.domain.TaxYear
-import shared.models.errors.MtdError
+import shared.models.errors.*
 import v1.residentialPropertyDisposals.deleteNonPpd.def1.model.request.Def1_DeleteCgtNonPpdRequestData
 import v1.residentialPropertyDisposals.deleteNonPpd.model.request.DeleteCgtNonPpdRequestData
 
@@ -31,7 +31,11 @@ import javax.inject.Inject
 class Def1_DeleteCgtNonPpdValidator @Inject() (nino: String, taxYear: String)(appConfig: CgtAppConfig) extends Validator[DeleteCgtNonPpdRequestData] {
 
   private lazy val minimumTaxYear = appConfig.minimumPermittedTaxYear
-  private lazy val resolveTaxYear = ResolveTaxYearMinimum(TaxYear.fromDownstreamInt(minimumTaxYear))
+
+  private lazy val resolveTaxYear = ResolveTaxYearMinMax(
+    (TaxYear.fromDownstreamInt(minimumTaxYear), TaxYear.fromMtd("2024-25")),
+    RuleTaxYearNotSupportedError,
+    RuleTaxYearForVersionNotSupportedError)
 
   def validate: Validated[Seq[MtdError], DeleteCgtNonPpdRequestData] =
     (

--- a/app/v1/residentialPropertyDisposals/retrieveAll/RetrieveAllResidentialPropertyCgtConnector.scala
+++ b/app/v1/residentialPropertyDisposals/retrieveAll/RetrieveAllResidentialPropertyCgtConnector.scala
@@ -16,8 +16,8 @@
 
 package v1.residentialPropertyDisposals.retrieveAll
 
-import shared.config.SharedAppConfig
-import shared.connectors.DownstreamUri.{DesUri, IfsUri}
+import shared.config.{ConfigFeatureSwitches, SharedAppConfig}
+import shared.connectors.DownstreamUri.{DesUri, HipUri, IfsUri}
 import shared.connectors.{BaseDownstreamConnector, DownstreamOutcome, DownstreamUri}
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.http.client.HttpClientV2
@@ -45,7 +45,11 @@ class RetrieveAllResidentialPropertyCgtConnector @Inject() (val http: HttpClient
 
     val downstreamUri: DownstreamUri[DownstreamResp] = taxYear match {
       case ty if ty.useTaxYearSpecificApi =>
-        IfsUri(s"income-tax/income/disposals/residential-property/${taxYear.asTysDownstream}/${nino.value}")
+        if (ConfigFeatureSwitches().isEnabled("ifs_hip_migration_1881")) {
+          HipUri(s"itsa/income-tax/v1/${taxYear.asTysDownstream}/income/disposals/residential-property/${nino.value}")
+        } else {
+          IfsUri(s"income-tax/income/disposals/residential-property/${taxYear.asTysDownstream}/${nino.value}")
+        }
       case _ =>
         DesUri(s"income-tax/income/disposals/residential-property/${nino.value}/${taxYear.asMtd}")
     }

--- a/app/v1/residentialPropertyDisposals/retrieveAll/def1/Def1_RetrieveAllResidentialPropertyCgtValidator.scala
+++ b/app/v1/residentialPropertyDisposals/retrieveAll/def1/Def1_RetrieveAllResidentialPropertyCgtValidator.scala
@@ -22,9 +22,9 @@ import cats.implicits.*
 import common.errors.SourceFormatError
 import config.CgtAppConfig
 import shared.controllers.validators.Validator
-import shared.controllers.validators.resolvers.{ResolveNino, ResolveTaxYearMinimum}
+import shared.controllers.validators.resolvers.{ResolveNino, ResolveTaxYearMinMax}
 import shared.models.domain.TaxYear
-import shared.models.errors.MtdError
+import shared.models.errors.{MtdError, RuleTaxYearForVersionNotSupportedError, RuleTaxYearNotSupportedError}
 import v1.residentialPropertyDisposals.retrieveAll.def1.model.MtdSourceEnum
 import v1.residentialPropertyDisposals.retrieveAll.def1.model.request.Def1_RetrieveAllResidentialPropertyRequestData
 import v1.residentialPropertyDisposals.retrieveAll.model.request.RetrieveAllResidentialPropertyCgtRequestData
@@ -37,7 +37,12 @@ class Def1_RetrieveAllResidentialPropertyCgtValidator @Inject() (nino: String, t
     extends Validator[RetrieveAllResidentialPropertyCgtRequestData] {
 
   private lazy val minimumTaxYear = appConfig.minimumPermittedTaxYear
-  private lazy val resolveTaxYear = ResolveTaxYearMinimum(TaxYear.fromDownstreamInt(minimumTaxYear))
+
+  private lazy val resolveTaxYear =
+    ResolveTaxYearMinMax(
+      (TaxYear.fromDownstreamInt(minimumTaxYear), TaxYear.fromMtd("2024-25")),
+      RuleTaxYearNotSupportedError,
+      RuleTaxYearForVersionNotSupportedError)
 
   def validate: Validated[Seq[MtdError], RetrieveAllResidentialPropertyCgtRequestData] =
     (

--- a/app/v2/otherCgt/createAmend/CreateAmendOtherCgtConnector.scala
+++ b/app/v2/otherCgt/createAmend/CreateAmendOtherCgtConnector.scala
@@ -16,8 +16,8 @@
 
 package v2.otherCgt.createAmend
 
-import shared.config.SharedAppConfig
-import shared.connectors.DownstreamUri.IfsUri
+import shared.config.{ConfigFeatureSwitches, SharedAppConfig}
+import shared.connectors.DownstreamUri.{HipUri, IfsUri}
 import shared.connectors.{BaseDownstreamConnector, DownstreamOutcome, DownstreamUri}
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.http.client.HttpClientV2
@@ -37,13 +37,15 @@ class CreateAmendOtherCgtConnector @Inject() (val http: HttpClientV2, val appCon
     import request.*
     import shared.connectors.httpparsers.StandardDownstreamHttpParser.*
 
-    val downstreamUri: DownstreamUri[Unit] =
-      if (taxYear.useTaxYearSpecificApi) {
-        IfsUri[Unit](s"income-tax/income/disposals/other-gains/${taxYear.asTysDownstream}/${nino.nino}")
-      } else {
-        IfsUri[Unit](s"income-tax/income/disposals/other-gains/${nino.nino}/${taxYear.asMtd}")
-      }
-    put(body, downstreamUri)
+    lazy val downstreamUri1886 = if (ConfigFeatureSwitches().isEnabled("ifs_hip_migration_1886")) {
+      HipUri[Unit](s"itsa/income-tax/v1/${taxYear.asTysDownstream}/income/disposals/other-gains/${nino.nino}")
+    } else {
+      IfsUri[Unit](s"income-tax/income/disposals/other-gains/${taxYear.asTysDownstream}/${nino.nino}")
+    }
+
+    lazy val downstreamUri1739 = IfsUri(s"income-tax/income/disposals/other-gains/${nino.nino}/${taxYear.asMtd}")
+
+    if (taxYear.useTaxYearSpecificApi) put(body, downstreamUri1886) else put(body, downstreamUri1739)
   }
 
 }

--- a/app/v2/otherCgt/delete/DeleteOtherCgtConnector.scala
+++ b/app/v2/otherCgt/delete/DeleteOtherCgtConnector.scala
@@ -16,8 +16,8 @@
 
 package v2.otherCgt.delete
 
-import shared.config.SharedAppConfig
-import shared.connectors.DownstreamUri.IfsUri
+import shared.config.{ConfigFeatureSwitches, SharedAppConfig}
+import shared.connectors.DownstreamUri.{HipUri, IfsUri}
 import shared.connectors.{BaseDownstreamConnector, DownstreamOutcome}
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.http.client.HttpClientV2
@@ -38,15 +38,15 @@ class DeleteOtherCgtConnector @Inject() (val http: HttpClientV2, val appConfig: 
 
     import request.*
 
-    val downstreamUri = if (taxYear.useTaxYearSpecificApi) {
-      IfsUri[Unit](
-        s"income-tax/income/disposals/other-gains/${taxYear.asTysDownstream}/${nino.value}"
-      )
+    lazy val downstreamUri1741 = IfsUri[Unit](s"income-tax/income/disposals/other-gains/${nino.value}/${taxYear.asMtd}")
+
+    lazy val downstreamUri1953 = if (ConfigFeatureSwitches().isEnabled("ifs_hip_migration_1953")) {
+      HipUri[Unit](s"itsa/income-tax/v1/${taxYear.asTysDownstream}/income/disposals/other-gains/${nino.value}")
     } else {
-      IfsUri[Unit](
-        s"income-tax/income/disposals/other-gains/${nino.value}/${taxYear.asMtd}"
-      )
+      IfsUri[Unit](s"income-tax/income/disposals/other-gains/${taxYear.asTysDownstream}/${nino.value}")
     }
+
+    val downstreamUri = if (taxYear.useTaxYearSpecificApi) downstreamUri1953 else downstreamUri1741
 
     delete(uri = downstreamUri)
 

--- a/app/v2/otherCgt/delete/def1/Def1_DeleteOtherCgtValidator.scala
+++ b/app/v2/otherCgt/delete/def1/Def1_DeleteOtherCgtValidator.scala
@@ -20,9 +20,9 @@ import cats.data.Validated
 import cats.implicits.*
 import config.CgtAppConfig
 import shared.controllers.validators.Validator
-import shared.controllers.validators.resolvers.{ResolveNino, ResolveTaxYearMinimum}
+import shared.controllers.validators.resolvers.{ResolveNino, ResolveTaxYearMinMax}
 import shared.models.domain.TaxYear
-import shared.models.errors.MtdError
+import shared.models.errors.{MtdError, RuleTaxYearForVersionNotSupportedError, RuleTaxYearNotSupportedError}
 import v2.otherCgt.delete.def1.model.request.Def1_DeleteOtherCgtRequestData
 import v2.otherCgt.delete.model.request.DeleteOtherCgtRequestData
 
@@ -31,7 +31,11 @@ import javax.inject.Inject
 class Def1_DeleteOtherCgtValidator @Inject() (nino: String, taxYear: String)(appConfig: CgtAppConfig) extends Validator[DeleteOtherCgtRequestData] {
 
   private lazy val minimumTaxYear = appConfig.minimumPermittedTaxYear
-  private lazy val resolveTaxYear = ResolveTaxYearMinimum(TaxYear.fromDownstreamInt(minimumTaxYear))
+
+  private lazy val resolveTaxYear = ResolveTaxYearMinMax(
+    (TaxYear.fromDownstreamInt(minimumTaxYear), TaxYear.fromMtd("2024-25")),
+    RuleTaxYearNotSupportedError,
+    RuleTaxYearForVersionNotSupportedError)
 
   def validate: Validated[Seq[MtdError], DeleteOtherCgtRequestData] =
     (

--- a/app/v2/otherCgt/retrieve/def1/Def1_RetrieveOtherCgtValidator.scala
+++ b/app/v2/otherCgt/retrieve/def1/Def1_RetrieveOtherCgtValidator.scala
@@ -20,9 +20,9 @@ import cats.data.Validated
 import cats.implicits.*
 import config.CgtAppConfig
 import shared.controllers.validators.Validator
-import shared.controllers.validators.resolvers.{ResolveNino, ResolveTaxYearMinimum}
+import shared.controllers.validators.resolvers.{ResolveNino, ResolveTaxYearMinMax}
 import shared.models.domain.TaxYear
-import shared.models.errors.MtdError
+import shared.models.errors.{MtdError, RuleTaxYearForVersionNotSupportedError, RuleTaxYearNotSupportedError}
 import v2.otherCgt.retrieve.def1.model.request.Def1_RetrieveOtherCgtRequestData
 import v2.otherCgt.retrieve.model.request.RetrieveOtherCgtRequestData
 
@@ -33,7 +33,11 @@ class Def1_RetrieveOtherCgtValidator @Inject() (nino: String, taxYear: String)(a
     extends Validator[RetrieveOtherCgtRequestData] {
 
   private lazy val minimumTaxYear = appConfig.minimumPermittedTaxYear
-  private lazy val resolveTaxYear = ResolveTaxYearMinimum(TaxYear.fromDownstreamInt(minimumTaxYear))
+
+  private lazy val resolveTaxYear = ResolveTaxYearMinMax(
+    (TaxYear.fromDownstreamInt(minimumTaxYear), TaxYear.fromMtd("2024-25")),
+    RuleTaxYearNotSupportedError,
+    RuleTaxYearForVersionNotSupportedError)
 
   def validate: Validated[Seq[MtdError], Def1_RetrieveOtherCgtRequestData] =
     (

--- a/app/v2/residentialPropertyDisposals/createAmendCgtPpdOverrides/CreateAmendCgtPpdOverridesConnector.scala
+++ b/app/v2/residentialPropertyDisposals/createAmendCgtPpdOverrides/CreateAmendCgtPpdOverridesConnector.scala
@@ -17,8 +17,8 @@
 package v2.residentialPropertyDisposals.createAmendCgtPpdOverrides
 
 import com.google.inject.Singleton
-import shared.config.SharedAppConfig
-import shared.connectors.DownstreamUri.IfsUri
+import shared.config.{ConfigFeatureSwitches, SharedAppConfig}
+import shared.connectors.DownstreamUri.{HipUri, IfsUri}
 import shared.connectors.{BaseDownstreamConnector, DownstreamOutcome}
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.http.client.HttpClientV2
@@ -38,14 +38,15 @@ class CreateAmendCgtPpdOverridesConnector @Inject() (val http: HttpClientV2, val
     import request.*
     import shared.connectors.httpparsers.StandardDownstreamHttpParser.*
 
-    val downstreamUri =
-      if (taxYear.useTaxYearSpecificApi) {
-        IfsUri[Unit](s"income-tax/income/disposals/residential-property/ppd/${taxYear.asTysDownstream}/$nino")
-      } else {
-        IfsUri[Unit](s"income-tax/income/disposals/residential-property/ppd/$nino/${taxYear.asMtd}")
-      }
+    lazy val downstream1946 = if (ConfigFeatureSwitches().isEnabled("ifs_hip_migration_1946")) {
+      HipUri[Unit](s"itsa/income-tax/v1/${taxYear.asTysDownstream}/income/disposals/residential-property/ppd/${nino.value}")
+    } else {
+      IfsUri[Unit](s"income-tax/income/disposals/residential-property/ppd/${taxYear.asTysDownstream}/${nino.value}")
+    }
 
-    put(body, downstreamUri)
+    lazy val downstream1724 = IfsUri[Unit](s"income-tax/income/disposals/residential-property/ppd/$nino/${taxYear.asMtd}")
+
+    if (taxYear.useTaxYearSpecificApi) put(body, downstream1946) else put(body, downstream1724)
   }
 
 }

--- a/app/v2/residentialPropertyDisposals/createAmendCgtPpdOverrides/def1/Def1_CreateAmendCgtPpdOverridesValidator.scala
+++ b/app/v2/residentialPropertyDisposals/createAmendCgtPpdOverrides/def1/Def1_CreateAmendCgtPpdOverridesValidator.scala
@@ -21,9 +21,9 @@ import cats.implicits.*
 import config.CgtAppConfig
 import play.api.libs.json.JsValue
 import shared.controllers.validators.Validator
-import shared.controllers.validators.resolvers.{ResolveNino, ResolveNonEmptyJsonObject, ResolveTaxYearMinimum}
+import shared.controllers.validators.resolvers.{ResolveNino, ResolveNonEmptyJsonObject, ResolveTaxYearMinMax}
 import shared.models.domain.TaxYear
-import shared.models.errors.MtdError
+import shared.models.errors.{MtdError, RuleTaxYearForVersionNotSupportedError, RuleTaxYearNotSupportedError}
 import v2.residentialPropertyDisposals.createAmendCgtPpdOverrides.def1.Def1_CreateAmendCgtPpdOverridesRulesValidator.validateBusinessRules
 import v2.residentialPropertyDisposals.createAmendCgtPpdOverrides.def1.model.request.{
   Def1_CreateAmendCgtPpdOverridesRequestBody,
@@ -34,9 +34,13 @@ import v2.residentialPropertyDisposals.createAmendCgtPpdOverrides.model.request.
 class Def1_CreateAmendCgtPpdOverridesValidator(nino: String, taxYear: String, body: JsValue)(appConfig: CgtAppConfig)
     extends Validator[CreateAmendCgtPpdOverridesRequestData] {
 
-  private lazy val minimumTaxYear = appConfig.minimumPermittedTaxYear
-  private lazy val resolveTaxYear = ResolveTaxYearMinimum(TaxYear.fromDownstreamInt(minimumTaxYear))
-  private val resolveJson         = new ResolveNonEmptyJsonObject[Def1_CreateAmendCgtPpdOverridesRequestBody]()
+  private lazy val resolveTaxYear = ResolveTaxYearMinMax(
+    (TaxYear.fromDownstreamInt(appConfig.minimumPermittedTaxYear), TaxYear.fromMtd("2024-25")),
+    RuleTaxYearNotSupportedError,
+    RuleTaxYearForVersionNotSupportedError
+  )
+
+  private val resolveJson = new ResolveNonEmptyJsonObject[Def1_CreateAmendCgtPpdOverridesRequestBody]()
 
   def validate: Validated[Seq[MtdError], CreateAmendCgtPpdOverridesRequestData] = (
     ResolveNino(nino),

--- a/app/v2/residentialPropertyDisposals/createAmendNonPpd/def1/Def1_CreateAmendCgtResidentialPropertyDisposalsValidator.scala
+++ b/app/v2/residentialPropertyDisposals/createAmendNonPpd/def1/Def1_CreateAmendCgtResidentialPropertyDisposalsValidator.scala
@@ -21,9 +21,9 @@ import cats.implicits.*
 import config.CgtAppConfig
 import play.api.libs.json.JsValue
 import shared.controllers.validators.Validator
-import shared.controllers.validators.resolvers.{ResolveNino, ResolveNonEmptyJsonObject, ResolveTaxYearMinimum}
+import shared.controllers.validators.resolvers.{ResolveNino, ResolveNonEmptyJsonObject, ResolveTaxYearMinMax}
 import shared.models.domain.TaxYear
-import shared.models.errors.MtdError
+import shared.models.errors.{MtdError, RuleTaxYearForVersionNotSupportedError, RuleTaxYearNotSupportedError}
 import v2.residentialPropertyDisposals.createAmendNonPpd.def1.Def1_CreateAmendCgtResidentialPropertyDisposalsRulesValidator.validateBusinessRules
 import v2.residentialPropertyDisposals.createAmendNonPpd.def1.model.request.{
   Def1_CreateAmendCgtResidentialPropertyDisposalsRequestBody,
@@ -35,8 +35,13 @@ class Def1_CreateAmendCgtResidentialPropertyDisposalsValidator(nino: String, tax
     extends Validator[CreateAmendCgtResidentialPropertyDisposalsRequestData] {
 
   private lazy val minimumTaxYear = appConfig.minimumPermittedTaxYear
-  private lazy val resolveTaxYear = ResolveTaxYearMinimum(TaxYear.fromDownstreamInt(minimumTaxYear))
-  private val resolveJson         = new ResolveNonEmptyJsonObject[Def1_CreateAmendCgtResidentialPropertyDisposalsRequestBody]()
+
+  private lazy val resolveTaxYear = ResolveTaxYearMinMax(
+    (TaxYear.fromDownstreamInt(minimumTaxYear), TaxYear.fromMtd("2024-25")),
+    RuleTaxYearNotSupportedError,
+    RuleTaxYearForVersionNotSupportedError)
+
+  private val resolveJson = new ResolveNonEmptyJsonObject[Def1_CreateAmendCgtResidentialPropertyDisposalsRequestBody]()
 
   def validate: Validated[Seq[MtdError], CreateAmendCgtResidentialPropertyDisposalsRequestData] = (
     ResolveNino(nino),

--- a/app/v2/residentialPropertyDisposals/deleteNonPpd/DeleteCgtNonPpdConnector.scala
+++ b/app/v2/residentialPropertyDisposals/deleteNonPpd/DeleteCgtNonPpdConnector.scala
@@ -16,10 +16,10 @@
 
 package v2.residentialPropertyDisposals.deleteNonPpd
 
-import shared.config.SharedAppConfig
-import shared.connectors.DownstreamUri.IfsUri
+import shared.config.{ConfigFeatureSwitches, SharedAppConfig}
+import shared.connectors.DownstreamUri.{HipUri, IfsUri}
 import shared.connectors.httpparsers.StandardDownstreamHttpParser.*
-import shared.connectors.{BaseDownstreamConnector, DownstreamOutcome}
+import shared.connectors.{BaseDownstreamConnector, DownstreamOutcome, DownstreamUri}
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.http.client.HttpClientV2
 import v2.residentialPropertyDisposals.deleteNonPpd.model.request.DeleteCgtNonPpdRequestData
@@ -37,15 +37,25 @@ class DeleteCgtNonPpdConnector @Inject() (val http: HttpClientV2, val appConfig:
 
     import request.*
 
-    val downstreamUri = if (taxYear.useTaxYearSpecificApi) {
-      IfsUri[Unit](s"income-tax/income/disposals/residential-property/${taxYear.asTysDownstream}/${nino.value}")
+    lazy val downstreamUri1875: DownstreamUri[Unit] = if (ConfigFeatureSwitches().isEnabled("ifs_hip_migration_1875")) {
+      HipUri[Unit](
+        s"itsa/income-tax/v1/${taxYear.asTysDownstream}/income/disposals/residential-property/$nino"
+      )
     } else {
-      // Note: tax year is in MTD format
-      IfsUri[Unit](s"income-tax/income/disposals/residential-property/${nino.value}/${taxYear.asMtd}")
+      IfsUri[Unit](
+        s"income-tax/income/disposals/residential-property/${taxYear.asTysDownstream}/$nino"
+      )
     }
 
-    delete(downstreamUri)
+    lazy val downstreamUri1740: DownstreamUri[Unit] = IfsUri[Unit](
+      s"income-tax/income/disposals/residential-property/$nino/${taxYear.asMtd}"
+    )
 
+    if (taxYear.useTaxYearSpecificApi) {
+      delete(uri = downstreamUri1875)
+    } else {
+      delete(uri = downstreamUri1740)
+    }
   }
 
 }

--- a/app/v2/residentialPropertyDisposals/deleteNonPpd/def1/Def1_DeleteCgtNonPpdValidator.scala
+++ b/app/v2/residentialPropertyDisposals/deleteNonPpd/def1/Def1_DeleteCgtNonPpdValidator.scala
@@ -20,9 +20,9 @@ import cats.data.Validated
 import cats.implicits.*
 import config.CgtAppConfig
 import shared.controllers.validators.Validator
-import shared.controllers.validators.resolvers.{ResolveNino, ResolveTaxYearMinimum}
+import shared.controllers.validators.resolvers.{ResolveNino, ResolveTaxYearMinMax}
 import shared.models.domain.TaxYear
-import shared.models.errors.MtdError
+import shared.models.errors.{MtdError, RuleTaxYearForVersionNotSupportedError, RuleTaxYearNotSupportedError}
 import v2.residentialPropertyDisposals.deleteNonPpd.def1.model.request.Def1_DeleteCgtNonPpdRequestData
 import v2.residentialPropertyDisposals.deleteNonPpd.model.request.DeleteCgtNonPpdRequestData
 
@@ -31,7 +31,11 @@ import javax.inject.Inject
 class Def1_DeleteCgtNonPpdValidator @Inject() (nino: String, taxYear: String)(appConfig: CgtAppConfig) extends Validator[DeleteCgtNonPpdRequestData] {
 
   private lazy val minimumTaxYear = appConfig.minimumPermittedTaxYear
-  private lazy val resolveTaxYear = ResolveTaxYearMinimum(TaxYear.fromDownstreamInt(minimumTaxYear))
+
+  private lazy val resolveTaxYear = ResolveTaxYearMinMax(
+    (TaxYear.fromDownstreamInt(minimumTaxYear), TaxYear.fromMtd("2024-25")),
+    RuleTaxYearNotSupportedError,
+    RuleTaxYearForVersionNotSupportedError)
 
   def validate: Validated[Seq[MtdError], DeleteCgtNonPpdRequestData] =
     (

--- a/app/v2/residentialPropertyDisposals/retrieveAll/RetrieveAllResidentialPropertyCgtConnector.scala
+++ b/app/v2/residentialPropertyDisposals/retrieveAll/RetrieveAllResidentialPropertyCgtConnector.scala
@@ -16,8 +16,8 @@
 
 package v2.residentialPropertyDisposals.retrieveAll
 
-import shared.config.SharedAppConfig
-import shared.connectors.DownstreamUri.{DesUri, IfsUri}
+import shared.config.{ConfigFeatureSwitches, SharedAppConfig}
+import shared.connectors.DownstreamUri.{DesUri, HipUri, IfsUri}
 import shared.connectors.{BaseDownstreamConnector, DownstreamOutcome, DownstreamUri}
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.http.client.HttpClientV2
@@ -45,7 +45,11 @@ class RetrieveAllResidentialPropertyCgtConnector @Inject() (val http: HttpClient
 
     val downstreamUri: DownstreamUri[DownstreamResp] = taxYear match {
       case ty if ty.useTaxYearSpecificApi =>
-        IfsUri(s"income-tax/income/disposals/residential-property/${taxYear.asTysDownstream}/${nino.value}")
+        if (ConfigFeatureSwitches().isEnabled("ifs_hip_migration_1881")) {
+          HipUri(s"itsa/income-tax/v1/${taxYear.asTysDownstream}/income/disposals/residential-property/${nino.value}")
+        } else {
+          IfsUri(s"income-tax/income/disposals/residential-property/${taxYear.asTysDownstream}/${nino.value}")
+        }
       case _ =>
         DesUri(s"income-tax/income/disposals/residential-property/${nino.value}/${taxYear.asMtd}")
     }

--- a/app/v2/residentialPropertyDisposals/retrieveAll/def1/Def1_RetrieveAllResidentialPropertyCgtValidator.scala
+++ b/app/v2/residentialPropertyDisposals/retrieveAll/def1/Def1_RetrieveAllResidentialPropertyCgtValidator.scala
@@ -22,9 +22,9 @@ import cats.implicits.*
 import common.errors.SourceFormatError
 import config.CgtAppConfig
 import shared.controllers.validators.Validator
-import shared.controllers.validators.resolvers.{ResolveNino, ResolveTaxYearMinimum}
+import shared.controllers.validators.resolvers.{ResolveNino, ResolveTaxYearMinMax}
 import shared.models.domain.TaxYear
-import shared.models.errors.MtdError
+import shared.models.errors.{MtdError, RuleTaxYearForVersionNotSupportedError, RuleTaxYearNotSupportedError}
 import v2.residentialPropertyDisposals.retrieveAll.def1.model.MtdSourceEnum
 import v2.residentialPropertyDisposals.retrieveAll.def1.model.request.Def1_RetrieveAllResidentialPropertyRequestData
 import v2.residentialPropertyDisposals.retrieveAll.model.request.RetrieveAllResidentialPropertyCgtRequestData
@@ -37,7 +37,12 @@ class Def1_RetrieveAllResidentialPropertyCgtValidator @Inject() (nino: String, t
     extends Validator[RetrieveAllResidentialPropertyCgtRequestData] {
 
   private lazy val minimumTaxYear = appConfig.minimumPermittedTaxYear
-  private lazy val resolveTaxYear = ResolveTaxYearMinimum(TaxYear.fromDownstreamInt(minimumTaxYear))
+
+  private lazy val resolveTaxYear =
+    ResolveTaxYearMinMax(
+      (TaxYear.fromDownstreamInt(minimumTaxYear), TaxYear.fromMtd("2024-25")),
+      RuleTaxYearNotSupportedError,
+      RuleTaxYearForVersionNotSupportedError)
 
   def validate: Validated[Seq[MtdError], RetrieveAllResidentialPropertyCgtRequestData] =
     (

--- a/it/test/v1/endpoints/CreateAmendCgtPpdOverridesControllerHipISpec.scala
+++ b/it/test/v1/endpoints/CreateAmendCgtPpdOverridesControllerHipISpec.scala
@@ -1,0 +1,537 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v1.endpoints
+
+import com.github.tomakehurst.wiremock.client.WireMock.*
+import com.github.tomakehurst.wiremock.stubbing.StubMapping
+import common.errors.*
+import play.api.http.HeaderNames.ACCEPT
+import play.api.http.Status.*
+import play.api.libs.json.{JsObject, JsValue, Json}
+import play.api.libs.ws.WSBodyWritables.writeableOf_JsValue
+import play.api.libs.ws.{WSRequest, WSResponse}
+import play.api.test.Helpers.AUTHORIZATION
+import shared.models.errors.*
+import shared.services.{AuditStub, AuthStub, DownstreamStub, MtdIdLookupStub}
+import shared.support.{IntegrationBaseSpec, WireMockMethods}
+
+class CreateAmendCgtPpdOverridesControllerHipISpec extends IntegrationBaseSpec with WireMockMethods {
+
+  val validRequestBodyJson: JsValue = Json.parse(
+    """
+      |{
+      |    "multiplePropertyDisposals": [
+      |         {
+      |            "ppdSubmissionId": "AB0000000092",
+      |            "amountOfNetGain": 1234.78
+      |         },
+      |         {
+      |            "ppdSubmissionId": "AB0000000098",
+      |            "amountOfNetLoss": 134.99
+      |         }
+      |    ],
+      |    "singlePropertyDisposals": [
+      |         {
+      |             "ppdSubmissionId": "AB0000000099",
+      |             "completionDate": "2020-02-28",
+      |             "disposalProceeds": 454.24,
+      |             "acquisitionDate": "2020-03-29",
+      |             "acquisitionAmount": 3434.45,
+      |             "improvementCosts": 233.45,
+      |             "additionalCosts": 423.34,
+      |             "prfAmount": 2324.67,
+      |             "otherReliefAmount": 3434.23,
+      |             "lossesFromThisYear": 436.23,
+      |             "lossesFromPreviousYear": 234.23,
+      |             "amountOfNetGain": 4567.89
+      |         },
+      |         {
+      |             "ppdSubmissionId": "AB0000000091",
+      |             "completionDate": "2020-02-28",
+      |             "disposalProceeds": 454.24,
+      |             "acquisitionDate": "2020-03-29",
+      |             "acquisitionAmount": 3434.45,
+      |             "improvementCosts": 233.45,
+      |             "additionalCosts": 423.34,
+      |             "prfAmount": 2324.67,
+      |             "otherReliefAmount": 3434.23,
+      |             "lossesFromThisYear": 436.23,
+      |             "lossesFromPreviousYear": 234.23,
+      |             "amountOfNetLoss": 4567.89
+      |         }
+      |    ]
+      |}
+      |""".stripMargin
+  )
+
+  val nonsenseBodyJson: JsValue = Json.parse(
+    """
+      |{
+      |  "aField": "aValue"
+      |}
+       """.stripMargin
+  )
+
+  val emptyFieldsJson: JsValue = Json.parse(
+    """
+      |{
+      |   "multiplePropertyDisposals": [],
+      |   "singlePropertyDisposals": []
+      |}
+     """.stripMargin
+  )
+
+  val emptyFieldsError: MtdError = RuleIncorrectOrEmptyBodyError.copy(
+    paths = Some(
+      Seq(
+        "/multiplePropertyDisposals",
+        "/singlePropertyDisposals"
+      ))
+  )
+
+  val missingFieldsJson: JsValue = Json.parse(
+    """
+      |{
+      |   "multiplePropertyDisposals": [{}],
+      |   "singlePropertyDisposals": [{}]
+      |}
+     """.stripMargin
+  )
+
+  val missingFieldsError: MtdError = RuleIncorrectOrEmptyBodyError.copy(
+    paths = Some(
+      Seq(
+        "/multiplePropertyDisposals/0/ppdSubmissionId",
+        "/singlePropertyDisposals/0/acquisitionAmount",
+        "/singlePropertyDisposals/0/additionalCosts",
+        "/singlePropertyDisposals/0/completionDate",
+        "/singlePropertyDisposals/0/disposalProceeds",
+        "/singlePropertyDisposals/0/improvementCosts",
+        "/singlePropertyDisposals/0/otherReliefAmount",
+        "/singlePropertyDisposals/0/ppdSubmissionId",
+        "/singlePropertyDisposals/0/prfAmount"
+      ))
+  )
+
+  val gainAndLossJson: JsValue = Json.parse(
+    """
+      |{
+      |    "multiplePropertyDisposals": [
+      |         {
+      |            "ppdSubmissionId": "AB0000000092",
+      |            "amountOfNetGain": 1234.78,
+      |            "amountOfNetLoss": 134.99
+      |         }
+      |    ],
+      |    "singlePropertyDisposals": [
+      |         {
+      |             "ppdSubmissionId": "AB0000000098",
+      |             "completionDate": "2020-02-28",
+      |             "disposalProceeds": 454.24,
+      |             "acquisitionDate": "2020-03-29",
+      |             "acquisitionAmount": 3434.45,
+      |             "improvementCosts": 233.45,
+      |             "additionalCosts": 423.34,
+      |             "prfAmount": 2324.67,
+      |             "otherReliefAmount": 3434.23,
+      |             "lossesFromThisYear": 436.23,
+      |             "lossesFromPreviousYear": 234.23,
+      |             "amountOfNetGain": 4567.89,
+      |             "amountOfNetLoss": 50000.99
+      |         }
+      |    ]
+      |}
+      |""".stripMargin
+  )
+
+  val amountGainLossError: MtdError = RuleAmountGainLossError.copy(
+    paths = Some(
+      Seq(
+        "/multiplePropertyDisposals/0",
+        "/singlePropertyDisposals/0"
+      ))
+  )
+
+  val lossGreaterThanGainJson: JsValue = Json.parse(
+    """
+      |{
+      |    "multiplePropertyDisposals": [
+      |         {
+      |            "ppdSubmissionId": "AB0000000092",
+      |            "amountOfNetGain": 1234.78
+      |         }
+      |    ],
+      |    "singlePropertyDisposals": [
+      |         {
+      |             "ppdSubmissionId": "AB0000000098",
+      |             "completionDate": "2020-02-28",
+      |             "disposalProceeds": 454.24,
+      |             "acquisitionDate": "2020-03-29",
+      |             "acquisitionAmount": 3434.45,
+      |             "improvementCosts": 233.45,
+      |             "additionalCosts": 423.34,
+      |             "prfAmount": 2324.67,
+      |             "otherReliefAmount": 3434.23,
+      |             "lossesFromThisYear": 6464.99,
+      |             "lossesFromPreviousYear": 234.23,
+      |             "amountOfNetGain": 4567.89
+      |         }
+      |    ]
+      |}
+      |""".stripMargin
+  )
+
+  private val invalidValueRequestBodyJson: JsValue = Json.parse(
+    """
+      |{
+      |    "multiplePropertyDisposals": [
+      |         {
+      |            "ppdSubmissionId": "AB0000000092",
+      |            "amountOfNetGain": 1234.787385
+      |         },
+      |         {
+      |            "ppdSubmissionId": "AB0000000092",
+      |            "amountOfNetLoss": -134.99
+      |         }
+      |    ],
+      |    "singlePropertyDisposals": [
+      |         {
+      |             "ppdSubmissionId": "AB0000000092",
+      |             "completionDate": "2020-02-28",
+      |             "disposalProceeds": 454.24999,
+      |             "acquisitionDate": "2020-03-29",
+      |             "acquisitionAmount": 3434.45346,
+      |             "improvementCosts": 233.4628,
+      |             "additionalCosts": 423.34829,
+      |             "prfAmount": -2324.67,
+      |             "otherReliefAmount": -3434.23,
+      |             "lossesFromThisYear": 436.23297423,
+      |             "lossesFromPreviousYear": 234.2334728,
+      |             "amountOfNetGain": 4567.8974726
+      |         },
+      |         {
+      |             "ppdSubmissionId": "AB0000000092",
+      |             "completionDate": "2020-02-28",
+      |             "disposalProceeds": -454.24,
+      |             "acquisitionDate": "2020-03-29",
+      |             "acquisitionAmount": 3434.45837,
+      |             "improvementCosts": 233.4628,
+      |             "additionalCosts": -423.34,
+      |             "prfAmount": 2324.678372,
+      |             "otherReliefAmount": -3434.23,
+      |             "lossesFromThisYear": 436.23287,
+      |             "lossesFromPreviousYear": -234.23,
+      |             "amountOfNetLoss": 4567.8983724
+      |         }
+      |    ]
+      |}
+      |""".stripMargin
+  )
+
+  val invalidValueErrors: MtdError = ValueFormatError.copy(
+    message = "The value must be between 0 and 99999999999.99",
+    paths = Some(
+      Seq(
+        "/multiplePropertyDisposals/0/amountOfNetGain",
+        "/multiplePropertyDisposals/1/amountOfNetLoss",
+        "/singlePropertyDisposals/0/disposalProceeds",
+        "/singlePropertyDisposals/0/acquisitionAmount",
+        "/singlePropertyDisposals/0/improvementCosts",
+        "/singlePropertyDisposals/0/additionalCosts",
+        "/singlePropertyDisposals/0/prfAmount",
+        "/singlePropertyDisposals/0/otherReliefAmount",
+        "/singlePropertyDisposals/0/lossesFromThisYear",
+        "/singlePropertyDisposals/0/lossesFromPreviousYear",
+        "/singlePropertyDisposals/0/amountOfNetGain",
+        "/singlePropertyDisposals/1/disposalProceeds",
+        "/singlePropertyDisposals/1/acquisitionAmount",
+        "/singlePropertyDisposals/1/improvementCosts",
+        "/singlePropertyDisposals/1/additionalCosts",
+        "/singlePropertyDisposals/1/prfAmount",
+        "/singlePropertyDisposals/1/otherReliefAmount",
+        "/singlePropertyDisposals/1/lossesFromThisYear",
+        "/singlePropertyDisposals/1/lossesFromPreviousYear",
+        "/singlePropertyDisposals/1/amountOfNetLoss"
+      ))
+  )
+
+  def jsonWithIds(multipleSubmissionId: String, singleSubmissionId: String): JsValue = Json.parse(
+    s"""
+       |{
+       |    "multiplePropertyDisposals": [
+       |         {
+       |            "ppdSubmissionId": "$multipleSubmissionId",
+       |            "amountOfNetGain": 1234.78
+       |         }
+       |    ],
+       |    "singlePropertyDisposals": [
+       |         {
+       |             "ppdSubmissionId": "$singleSubmissionId",
+       |             "completionDate": "2020-02-28",
+       |             "disposalProceeds": 454.24,
+       |             "acquisitionDate": "2020-03-29",
+       |             "acquisitionAmount": 3434.45,
+       |             "improvementCosts": 233.45,
+       |             "additionalCosts": 423.34,
+       |             "prfAmount": 2324.67,
+       |             "otherReliefAmount": 3434.23,
+       |             "lossesFromThisYear": 436.23,
+       |             "lossesFromPreviousYear": 234.23,
+       |             "amountOfNetGain": 4567.89
+       |         }
+       |    ]
+       |}
+       |""".stripMargin
+  )
+
+  val ppdSubmissionFormatError: MtdError = PpdSubmissionIdFormatError.copy(
+    paths = Some(
+      Seq(
+        "/multiplePropertyDisposals/0/ppdSubmissionId",
+        "/singlePropertyDisposals/0/ppdSubmissionId"
+      ))
+  )
+
+  val invalidDateFormatJson: JsValue = Json.parse(
+    """
+      |{
+      |    "multiplePropertyDisposals": [
+      |         {
+      |            "ppdSubmissionId": "AB0000000091",
+      |            "amountOfNetGain": 1234.78
+      |         }
+      |    ],
+      |    "singlePropertyDisposals": [
+      |         {
+      |             "ppdSubmissionId": "AB0000000092",
+      |             "completionDate": "20-02-28",
+      |             "disposalProceeds": 454.24,
+      |             "acquisitionDate": "2003-29",
+      |             "acquisitionAmount": 3434.45,
+      |             "improvementCosts": 233.45,
+      |             "additionalCosts": 423.34,
+      |             "prfAmount": 2324.67,
+      |             "otherReliefAmount": 3434.23,
+      |             "lossesFromThisYear": 436.23,
+      |             "lossesFromPreviousYear": 234.23,
+      |             "amountOfNetGain": 4567.89
+      |         }
+      |    ]
+      |}
+      |""".stripMargin
+  )
+
+  val dateFormatError: MtdError = DateFormatError.copy(
+    paths = Some(
+      Seq(
+        "/singlePropertyDisposals/0/completionDate",
+        "/singlePropertyDisposals/0/acquisitionDate"
+      ))
+  )
+
+  private trait Test {
+
+    def nino: String = "AA123456A"
+    def taxYear: String
+    def downstreamUri: String
+    def uri: String = s"/residential-property/$nino/$taxYear/ppd"
+
+    def setupStubs(): StubMapping
+
+    def request: WSRequest = {
+      setupStubs()
+      buildRequest(uri)
+        .withHttpHeaders(
+          (ACCEPT, "application/vnd.hmrc.1.0+json"),
+          (AUTHORIZATION, "Bearer 123") // some bearer token
+        )
+    }
+
+    def verifyNrs(payload: JsValue): Unit =
+      verify(
+        postRequestedFor(urlEqualTo(s"/mtd-api-nrs-proxy/$nino/itsa-cgt-disposal-ppd"))
+          .withRequestBody(equalToJson(payload.toString())))
+
+  }
+
+  private trait NonTysTest extends Test {
+    def taxYear               = "2019-20"
+    def downstreamUri: String = s"/income-tax/income/disposals/residential-property/ppd/$nino/$taxYear"
+  }
+
+  private trait TysHipTest extends Test {
+    def taxYear               = "2024-25"
+    def downstreamUri: String = s"/itsa/income-tax/v1/24-25/income/disposals/residential-property/ppd/$nino"
+
+    override def request: WSRequest =
+      super.request.addHttpHeaders("suspend-temporal-validations" -> "true")
+
+  }
+
+  "Calling Create and Amend 'Report and Pay Capital Gains Tax on Property' Overrides endpoint" should {
+    "return a 200 status code" when {
+      "any valid request is made" in new NonTysTest {
+
+        override def setupStubs(): StubMapping = {
+          AuthStub.authorised()
+          MtdIdLookupStub.ninoFound(nino)
+          DownstreamStub.onSuccess(DownstreamStub.PUT, downstreamUri, NO_CONTENT)
+        }
+
+        val response: WSResponse = await(request.put(validRequestBodyJson))
+        response.status shouldBe OK
+
+        verifyNrs(validRequestBodyJson)
+      }
+
+      "any valid request is made for a TYS tax year" in new TysHipTest {
+
+        override def setupStubs(): StubMapping = {
+          AuthStub.authorised()
+          MtdIdLookupStub.ninoFound(nino)
+          DownstreamStub.onSuccess(DownstreamStub.PUT, downstreamUri, NO_CONTENT)
+        }
+
+        val response: WSResponse = await(request.put(validRequestBodyJson))
+        response.status shouldBe OK
+
+        verifyNrs(validRequestBodyJson)
+      }
+    }
+
+    "return a 400 with multiple errors" when {
+      "validation error" when {
+        def validationErrorTest(requestNino: String,
+                                requestTaxYear: String,
+                                requestBody: JsValue,
+                                expectedStatus: Int,
+                                expectedError: MtdError,
+                                expectedErrors: Option[ErrorWrapper],
+                                scenario: Option[String]): Unit = {
+          s"validation fails with ${expectedError.code} error${scenario.fold("")(scenario => s" for $scenario scenario")}" in new NonTysTest {
+            override val nino: String    = requestNino
+            override val taxYear: String = requestTaxYear
+
+            override def setupStubs(): StubMapping = {
+              AuditStub.audit()
+              AuthStub.authorised()
+              MtdIdLookupStub.ninoFound(nino)
+            }
+
+            val response: WSResponse = await(request.put(requestBody))
+            response.status shouldBe expectedStatus
+            response.json shouldBe expectedErrors.fold(Json.toJson(expectedError))(errorWrapper => Json.toJson(errorWrapper))
+            response.header("Content-Type") shouldBe Some("application/json")
+          }
+
+          s"validation fails with ${expectedError.code} error${scenario.fold("")(scenario => s" for $scenario scenario")} for TYS tax year" in new TysHipTest {
+            override val nino: String    = requestNino
+            override val taxYear: String = requestTaxYear
+
+            override def setupStubs(): StubMapping = {
+              AuditStub.audit()
+              AuthStub.authorised()
+              MtdIdLookupStub.ninoFound(nino)
+            }
+
+            val response: WSResponse = await(request.put(requestBody))
+            response.status shouldBe expectedStatus
+            response.json shouldBe expectedErrors.fold(Json.toJson(expectedError))(errorWrapper => Json.toJson(errorWrapper))
+            response.header("Content-Type") shouldBe Some("application/json")
+          }
+        }
+
+        val input = Seq(
+          // Path errors
+          ("AA1123A", "2020-21", validRequestBodyJson, BAD_REQUEST, NinoFormatError, None, None),
+          ("AA123456A", "20177", validRequestBodyJson, BAD_REQUEST, TaxYearFormatError, None, None),
+          ("AA123456A", "2015-17", validRequestBodyJson, BAD_REQUEST, RuleTaxYearRangeInvalidError, None, None),
+          ("AA123456A", "2018-19", validRequestBodyJson, BAD_REQUEST, RuleTaxYearNotSupportedError, None, None),
+          ("AA123456A", "2025-26", validRequestBodyJson, BAD_REQUEST, RuleTaxYearForVersionNotSupportedError, None, None),
+
+          // Body Errors
+          ("AA123456A", "2020-21", JsObject.empty, BAD_REQUEST, RuleIncorrectOrEmptyBodyError, None, Some("emptyBody")),
+          ("AA123456A", "2020-21", nonsenseBodyJson, BAD_REQUEST, RuleIncorrectOrEmptyBodyError, None, Some("nonsenseBody")),
+          ("AA123456A", "2020-21", emptyFieldsJson, BAD_REQUEST, emptyFieldsError, None, Some("emptyFields")),
+          ("AA123456A", "2020-21", missingFieldsJson, BAD_REQUEST, missingFieldsError, None, Some("missingFields")),
+          ("AA123456A", "2020-21", gainAndLossJson, BAD_REQUEST, amountGainLossError, None, Some("gainAndLossRule")),
+          ("AA123456A", "2020-21", invalidDateFormatJson, BAD_REQUEST, dateFormatError, None, Some("dateFormat")),
+          ("AA123456A", "2020-21", invalidValueRequestBodyJson, BAD_REQUEST, invalidValueErrors, None, Some("invalidNumValues")),
+          ("AA123456A", "2020-21", jsonWithIds("notAnID", "notAnID"), BAD_REQUEST, ppdSubmissionFormatError, None, Some("badIDs"))
+        )
+        input.foreach(args => (validationErrorTest).tupled(args))
+      }
+
+      "ifs service error" when {
+        def serviceErrorTest(ifsStatus: Int, ifsCode: String, expectedStatus: Int, expectedBody: MtdError): Unit = {
+          s"ifs returns an $ifsCode error and status $ifsStatus" in new NonTysTest {
+
+            override def setupStubs(): StubMapping = {
+              AuditStub.audit()
+              AuthStub.authorised()
+              MtdIdLookupStub.ninoFound(nino)
+              DownstreamStub.onError(DownstreamStub.PUT, downstreamUri, ifsStatus, errorBody(ifsCode))
+            }
+
+            val response: WSResponse = await(request.put(validRequestBodyJson))
+            response.status shouldBe expectedStatus
+            response.json shouldBe Json.toJson(expectedBody)
+            response.header("Content-Type") shouldBe Some("application/json")
+
+            verifyNrs(validRequestBodyJson)
+          }
+
+        }
+
+        def errorBody(code: String): String =
+          s"""
+             |{
+             |  "origin": "HoD",
+             |  "response": {
+             |    "failures": [
+             |      {
+             |        "type": "$code",
+             |        "reason": "message"
+             |      }
+             |    ]
+             |  }
+             |}
+            """.stripMargin
+
+        val errors = Seq(
+          (BAD_REQUEST, "INVALID_TAXABLE_ENTITY_ID", BAD_REQUEST, NinoFormatError),
+          (BAD_REQUEST, "INVALID_TAX_YEAR", BAD_REQUEST, TaxYearFormatError),
+          (BAD_REQUEST, "INVALID_CORRELATIONID", INTERNAL_SERVER_ERROR, InternalError),
+          (BAD_REQUEST, "INVALID_PAYLOAD", INTERNAL_SERVER_ERROR, InternalError),
+          (NOT_FOUND, "PPD_SUBMISSIONID_NOT_FOUND", NOT_FOUND, PpdSubmissionIdNotFoundError),
+          (NOT_FOUND, "NO_PPD_SUBMISSIONS_FOUND", NOT_FOUND, NotFoundError),
+          (CONFLICT, "DUPLICATE_SUBMISSION", BAD_REQUEST, RuleDuplicatedPpdSubmissionIdError),
+          (UNPROCESSABLE_ENTITY, "INVALID_DISPOSAL_TYPE", BAD_REQUEST, RuleIncorrectDisposalTypeError),
+          (INTERNAL_SERVER_ERROR, "SERVER_ERROR", INTERNAL_SERVER_ERROR, InternalError),
+          (SERVICE_UNAVAILABLE, "SERVICE_UNAVAILABLE", INTERNAL_SERVER_ERROR, InternalError)
+        )
+
+        val extraTysErrors = Seq(
+          (BAD_REQUEST, "TAX_YEAR_NOT_SUPPORTED", BAD_REQUEST, RuleTaxYearNotSupportedError)
+        )
+
+        (errors ++ extraTysErrors).foreach(args => (serviceErrorTest).tupled(args))
+      }
+    }
+  }
+
+}

--- a/it/test/v1/endpoints/CreateAmendCgtResidentialPropertyDisposalsControllerIfsISpec.scala
+++ b/it/test/v1/endpoints/CreateAmendCgtResidentialPropertyDisposalsControllerIfsISpec.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package v2.endpoints
+package v1.endpoints
 
 import com.github.tomakehurst.wiremock.client.WireMock.*
 import com.github.tomakehurst.wiremock.stubbing.StubMapping
@@ -29,7 +29,10 @@ import shared.models.errors.*
 import shared.services.*
 import shared.support.{IntegrationBaseSpec, WireMockMethods}
 
-class CreateAmendCgtResidentialPropertyDisposalsControllerISpec extends IntegrationBaseSpec with WireMockMethods {
+class CreateAmendCgtResidentialPropertyDisposalsControllerIfsISpec extends IntegrationBaseSpec with WireMockMethods {
+
+  override def servicesConfig: Map[String, Any] =
+    Map("feature-switch.ifs_hip_migration_1952.enabled" -> false) ++ super.servicesConfig
 
   val validDisposalDate: String    = "2020-03-27"
   val validCompletionDate: String  = "2020-03-29"
@@ -292,7 +295,7 @@ class CreateAmendCgtResidentialPropertyDisposalsControllerISpec extends Integrat
       setupStubs()
       buildRequest(s"/residential-property/$nino/$taxYear")
         .withHttpHeaders(
-          (ACCEPT, "application/vnd.hmrc.2.0+json"),
+          (ACCEPT, "application/vnd.hmrc.1.0+json"),
           (AUTHORIZATION, "Bearer 123") // some bearer token
         )
     }
@@ -385,6 +388,7 @@ class CreateAmendCgtResidentialPropertyDisposalsControllerISpec extends Integrat
           ("AA123456A", "20177", validRequestJson, BAD_REQUEST, TaxYearFormatError, None, None),
           ("AA123456A", "2015-17", validRequestJson, BAD_REQUEST, RuleTaxYearRangeInvalidError, None, None),
           ("AA123456A", "2018-19", validRequestJson, BAD_REQUEST, RuleTaxYearNotSupportedError, None, None),
+          ("AA123456A", "2025-26", validRequestJson, BAD_REQUEST, RuleTaxYearForVersionNotSupportedError, None, None),
 
           // Body errors
           ("AA123456A", "2019-20", JsObject.empty, BAD_REQUEST, RuleIncorrectOrEmptyBodyError, None, Some("emptyBody")),
@@ -397,7 +401,7 @@ class CreateAmendCgtResidentialPropertyDisposalsControllerISpec extends Integrat
           ("AA123456A", "2019-20", customerRefTooShortJson, BAD_REQUEST, customerRefError, None, Some("empty customer reference string")),
           ("AA123456A", "2019-20", gainLossJson, BAD_REQUEST, gainLossError, None, Some("gain and loss provided"))
         )
-        input.foreach(args => (validationErrorTest).tupled(args))
+        input.foreach(args => validationErrorTest.tupled(args))
       }
 
       "service error" when {
@@ -436,7 +440,6 @@ class CreateAmendCgtResidentialPropertyDisposalsControllerISpec extends Integrat
           (UNPROCESSABLE_ENTITY, "INVALID_DISPOSAL_DATE", BAD_REQUEST, RuleDisposalDateErrorV1),
           (UNPROCESSABLE_ENTITY, "INVALID_COMPLETION_DATE", BAD_REQUEST, RuleCompletionDateError),
           (UNPROCESSABLE_ENTITY, "INVALID_ACQUISITION_DATE", BAD_REQUEST, RuleAcquisitionDateAfterDisposalDateError),
-          (UNPROCESSABLE_ENTITY, "OUTSIDE_AMENDMENT_WINDOW", BAD_REQUEST, RuleOutsideAmendmentWindowError),
           (INTERNAL_SERVER_ERROR, "SERVER_ERROR", INTERNAL_SERVER_ERROR, InternalError),
           (SERVICE_UNAVAILABLE, "SERVICE_UNAVAILABLE", INTERNAL_SERVER_ERROR, InternalError)
         )
@@ -446,7 +449,7 @@ class CreateAmendCgtResidentialPropertyDisposalsControllerISpec extends Integrat
           (BAD_REQUEST, "INVALID_CORRELATION_ID", INTERNAL_SERVER_ERROR, InternalError)
         )
 
-        (errors ++ extraTysErrors).foreach(args => (serviceErrorTest).tupled(args))
+        (errors ++ extraTysErrors).foreach(args => serviceErrorTest.tupled(args))
       }
     }
   }

--- a/it/test/v1/endpoints/CreateAmendOtherCgtControllerIfsISpec.scala
+++ b/it/test/v1/endpoints/CreateAmendOtherCgtControllerIfsISpec.scala
@@ -1,0 +1,502 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v1.endpoints
+
+import com.github.tomakehurst.wiremock.client.WireMock.*
+import common.errors.*
+import play.api.http.HeaderNames.ACCEPT
+import play.api.http.Status.*
+import play.api.libs.json.{JsObject, JsValue, Json}
+import play.api.libs.ws.WSBodyWritables.writeableOf_JsValue
+import play.api.libs.ws.{WSRequest, WSResponse}
+import play.api.test.Helpers.AUTHORIZATION
+import shared.models.errors.*
+import shared.services.*
+import shared.support.{IntegrationBaseSpec, WireMockMethods}
+
+class CreateAmendOtherCgtControllerIfsISpec extends IntegrationBaseSpec with WireMockMethods {
+
+  override def servicesConfig: Map[String, Any] =
+    Map("feature-switch.ifs_hip_migration_1886.enabled" -> false) ++ super.servicesConfig
+
+  val validRequestJson: JsValue = Json.parse(
+    """
+      |{
+      |   "disposals":[
+      |      {
+      |         "assetType":"other-property",
+      |         "assetDescription":"string",
+      |         "acquisitionDate":"2021-05-07",
+      |         "disposalDate":"2021-05-07",
+      |         "disposalProceeds":59999999999.99,
+      |         "allowableCosts":59999999999.99,
+      |         "gain":59999999999.99,
+      |         "claimOrElectionCodes":[
+      |            "OTH"
+      |         ],
+      |         "gainAfterRelief":59999999999.99,
+      |         "rttTaxPaid":59999999999.99
+      |      }
+      |   ],
+      |   "nonStandardGains":{
+      |      "carriedInterestGain":19999999999.99,
+      |      "carriedInterestRttTaxPaid":19999999999.99,
+      |      "attributedGains":19999999999.99,
+      |      "attributedGainsRttTaxPaid":19999999999.99,
+      |      "otherGains":19999999999.99,
+      |      "otherGainsRttTaxPaid":19999999999.99
+      |   },
+      |   "losses":{
+      |      "broughtForwardLossesUsedInCurrentYear":29999999999.99,
+      |      "setAgainstInYearGains":29999999999.99,
+      |      "setAgainstInYearGeneralIncome":29999999999.99,
+      |      "setAgainstEarlierYear":29999999999.99
+      |   },
+      |   "adjustments":-39999999999.99
+      |}
+     """.stripMargin
+  )
+
+  val noMeaningfulDataJson: JsValue = Json.parse(
+    """
+      |{
+      |  "aField": "aValue"
+      |}
+       """.stripMargin
+  )
+
+  val emptyFieldsJson: JsValue = Json.parse(
+    """
+      |{
+      |   "disposals": [],
+      |   "nonStandardGains": {},
+      |   "losses": {}
+      |}
+     """.stripMargin
+  )
+
+  val emptyFieldsError: MtdError = RuleIncorrectOrEmptyBodyError.copy(
+    paths = Some(Seq("/disposals", "/nonStandardGains", "/losses"))
+  )
+
+  val missingFieldsJson: JsValue = Json.parse(
+    """
+      |{
+      |   "disposals": [{}]
+      |}
+     """.stripMargin
+  )
+
+  val missingFieldsError: MtdError = RuleIncorrectOrEmptyBodyError.copy(
+    paths = Some(
+      Seq(
+        "/disposals/0/acquisitionDate",
+        "/disposals/0/allowableCosts",
+        "/disposals/0/assetDescription",
+        "/disposals/0/assetType",
+        "/disposals/0/disposalDate",
+        "/disposals/0/disposalProceeds"
+      ))
+  )
+
+  val gainAndLossJson: JsValue = Json.parse(
+    """
+      |{
+      |   "disposals": [
+      |     {
+      |       "assetType":"other-property",
+      |       "assetDescription":"string",
+      |       "acquisitionDate":"2021-05-07",
+      |       "disposalDate":"2021-05-07",
+      |       "disposalProceeds":59999999999.99,
+      |       "allowableCosts":59999999999.99,
+      |       "gain":59999999999.99,
+      |       "loss":1234123.44,
+      |       "claimOrElectionCodes":[
+      |          "OTH"
+      |       ],
+      |       "gainAfterRelief":59999999999.99,
+      |       "lossAfterRelief":59999999999.99,
+      |       "rttTaxPaid":59999999999.99
+      |     }
+      |   ]
+      |}
+     """.stripMargin
+  )
+
+  val gainAndLossErrors: ErrorWrapper = ErrorWrapper(
+    correlationId = "",
+    BadRequestError,
+    Some(
+      Seq(
+        RuleGainAfterReliefLossAfterReliefError.copy(
+          paths = Some(
+            Seq(
+              "/disposals/0"
+            ))
+        ),
+        RuleGainLossError.copy(
+          paths = Some(
+            Seq(
+              "/disposals/0"
+            ))
+        )))
+  )
+
+  val decimalsTooBigJson: JsValue = Json.parse(
+    """
+      |{
+      |   "disposals":[
+      |      {
+      |         "assetType":"other-property",
+      |         "assetDescription":"string",
+      |         "acquisitionDate":"2021-05-07",
+      |         "disposalDate":"2021-05-07",
+      |         "disposalProceeds": 999999999999.99,
+      |         "allowableCosts": 999999999999.99,
+      |         "gain": 999999999999.99,
+      |         "claimOrElectionCodes":[
+      |            "OTH"
+      |         ],
+      |         "gainAfterRelief": 999999999999.99,
+      |         "rttTaxPaid": 999999999999.99
+      |      }
+      |   ],
+      |   "nonStandardGains":{
+      |      "carriedInterestGain": 999999999999.99,
+      |      "carriedInterestRttTaxPaid": 999999999999.99,
+      |      "attributedGains": 999999999999.99,
+      |      "attributedGainsRttTaxPaid": 999999999999.99,
+      |      "otherGains": 999999999999.99,
+      |      "otherGainsRttTaxPaid": 999999999999.99
+      |   },
+      |   "losses":{
+      |      "broughtForwardLossesUsedInCurrentYear": 999999999999.99,
+      |      "setAgainstInYearGains": 999999999999.99,
+      |      "setAgainstInYearGeneralIncome": 999999999999.99,
+      |      "setAgainstEarlierYear": 999999999999.99
+      |   },
+      |   "adjustments": 999999999999.99
+      |}
+     """.stripMargin
+  )
+
+  val decimalsTooSmallJson: JsValue = Json.parse(
+    """
+      |{
+      |   "disposals":[
+      |      {
+      |         "assetType":"other-property",
+      |         "assetDescription":"string",
+      |         "acquisitionDate":"2021-05-07",
+      |         "disposalDate":"2021-05-07",
+      |         "disposalProceeds": -0.01,
+      |         "allowableCosts": -0.01,
+      |         "gain": -0.01,
+      |         "claimOrElectionCodes":[
+      |            "OTH"
+      |         ],
+      |         "gainAfterRelief": -0.01,
+      |         "rttTaxPaid": -0.01
+      |      }
+      |   ],
+      |   "nonStandardGains":{
+      |      "carriedInterestGain": -0.01,
+      |      "carriedInterestRttTaxPaid": -0.01,
+      |      "attributedGains": -0.01,
+      |      "attributedGainsRttTaxPaid": -0.01,
+      |      "otherGains": -0.01,
+      |      "otherGainsRttTaxPaid": -0.01
+      |   },
+      |   "losses":{
+      |      "broughtForwardLossesUsedInCurrentYear": -0.01,
+      |      "setAgainstInYearGains": -0.01,
+      |      "setAgainstInYearGeneralIncome": -0.01,
+      |      "setAgainstEarlierYear": -0.01
+      |   },
+      |   "adjustments": -999999999999.99
+      |}
+     """.stripMargin
+  )
+
+  val positiveDecimalsOutOfRangeError: MtdError = ValueFormatError.copy(
+    message = "The value must be between 0 and 99999999999.99",
+    paths = Some(
+      Seq(
+        "/disposals/0/disposalProceeds",
+        "/disposals/0/allowableCosts",
+        "/disposals/0/gain",
+        "/disposals/0/gainAfterRelief",
+        "/disposals/0/rttTaxPaid",
+        "/nonStandardGains/carriedInterestGain",
+        "/nonStandardGains/carriedInterestRttTaxPaid",
+        "/nonStandardGains/attributedGains",
+        "/nonStandardGains/attributedGainsRttTaxPaid",
+        "/nonStandardGains/otherGains",
+        "/nonStandardGains/otherGainsRttTaxPaid",
+        "/losses/broughtForwardLossesUsedInCurrentYear",
+        "/losses/setAgainstInYearGains",
+        "/losses/setAgainstInYearGeneralIncome",
+        "/losses/setAgainstEarlierYear"
+      ))
+  )
+
+  val decimalsOutOfRangeErrors: ErrorWrapper = ErrorWrapper(
+    correlationId = "",
+    BadRequestError,
+    Some(
+      Seq(
+        positiveDecimalsOutOfRangeError,
+        ValueFormatError.copy(
+          message = "The value must be between -99999999999.99 and 99999999999.99",
+          paths = Some(
+            Seq(
+              "/adjustments"
+            ))
+        )
+      ))
+  )
+
+  val formatDisposalsJson: JsValue = Json.parse(
+    """
+      |{
+      |   "disposals":[
+      |      {
+      |         "assetType":"notEnumValue",
+      |         "assetDescription":"",
+      |         "acquisitionDate":"",
+      |         "disposalDate":"",
+      |         "disposalProceeds":59999999999.99,
+      |         "allowableCosts":59999999999.99,
+      |         "gain":59999999999.99,
+      |         "claimOrElectionCodes":[
+      |            "bip",
+      |            "bop"
+      |         ],
+      |         "gainAfterRelief":59999999999.99,
+      |         "rttTaxPaid":59999999999.99
+      |      }
+      |   ]
+      |}
+     """.stripMargin
+  )
+
+  val formatDisposalsErrors: ErrorWrapper = ErrorWrapper(
+    correlationId = "",
+    BadRequestError,
+    Some(
+      Seq(
+        AssetDescriptionFormatError.copy(
+          paths = Some(
+            Seq(
+              "/disposals/0/assetDescription"
+            ))
+        ),
+        AssetTypeFormatError.copy(
+          paths = Some(
+            Seq(
+              "/disposals/0/assetType"
+            ))
+        ),
+        ClaimOrElectionCodesFormatError.copy(
+          paths = Some(
+            Seq(
+              "/disposals/0/claimOrElectionCodes/0",
+              "/disposals/0/claimOrElectionCodes/1"
+            ))
+        ),
+        DateFormatError.copy(
+          paths = Some(
+            Seq(
+              "/disposals/0/disposalDate",
+              "/disposals/0/acquisitionDate"
+            ))
+        )
+      ))
+  )
+
+  val formatNonStandardGainsJson: JsValue = Json.parse(
+    """
+      |{
+      |   "nonStandardGains":{
+      |      "carriedInterestRttTaxPaid":19999999999.99,
+      |      "attributedGainsRttTaxPaid":19999999999.99,
+      |      "otherGainsRttTaxPaid":19999999999.99
+      |   }
+      |}
+     """.stripMargin
+  )
+
+  val formatNonStandardGainsError: MtdError = RuleIncorrectOrEmptyBodyError.copy(
+    paths = Some(Seq("/nonStandardGains"))
+  )
+
+  private trait Test {
+    val nino: String    = "AA123456A"
+    val taxYear: String = "2021-22"
+
+    def uri: String = s"/other-gains/$nino/$taxYear"
+
+    def setupStubs(): Unit = ()
+
+    def request: WSRequest = {
+      AuditStub.audit()
+      AuthStub.authorised()
+      MtdIdLookupStub.ninoFound(nino)
+      setupStubs()
+      buildRequest(uri)
+        .withHttpHeaders(
+          (ACCEPT, "application/vnd.hmrc.1.0+json"),
+          (AUTHORIZATION, "Bearer 123") // some bearer token
+        )
+    }
+
+    def verifyNrs(payload: JsValue): Unit =
+      verify(
+        postRequestedFor(urlEqualTo(s"/mtd-api-nrs-proxy/$nino/itsa-cgt-disposal-other"))
+          .withRequestBody(equalToJson(payload.toString())))
+
+  }
+
+  private trait NonTysTest extends Test {
+    def downstreamUrl: String = s"/income-tax/income/disposals/other-gains/$nino/$taxYear"
+
+  }
+
+  private trait TysIfsTest extends Test {
+
+    override val taxYear: String = "2023-24"
+
+    override def request: WSRequest =
+      super.request.addHttpHeaders("suspend-temporal-validations" -> "true")
+
+    def downstreamUrl: String = s"/income-tax/income/disposals/other-gains/23-24/$nino"
+
+  }
+
+  "Calling the 'create and amend other CGT' endpoint" should {
+    "return a 200 status code" when {
+      "any valid request is made" in new NonTysTest {
+
+        override def setupStubs(): Unit = {
+          DownstreamStub.onSuccess(DownstreamStub.PUT, downstreamUrl, NO_CONTENT, JsObject.empty)
+        }
+
+        val response: WSResponse = await(request.put(validRequestJson))
+        response.status shouldBe OK
+        verifyNrs(validRequestJson)
+      }
+
+      "any valid request is made TYS" in new TysIfsTest {
+
+        override def setupStubs(): Unit = {
+          DownstreamStub.onSuccess(DownstreamStub.PUT, downstreamUrl, NO_CONTENT, JsObject.empty)
+        }
+
+        val response: WSResponse = await(request.put(validRequestJson))
+        response.status shouldBe OK
+        verifyNrs(validRequestJson)
+      }
+    }
+
+    "return error according to spec" when {
+      "validation error" when {
+        def validationErrorTest(requestNino: String,
+                                requestTaxYear: String,
+                                requestBody: JsValue,
+                                expectedStatus: Int,
+                                expectedError: MtdError,
+                                expectedErrors: Option[ErrorWrapper],
+                                scenario: Option[String]): Unit = {
+          s"validation fails with ${expectedError.code} error${scenario.fold("")(scenario => s" for $scenario scenario")}" in new NonTysTest {
+
+            override val nino: String    = requestNino
+            override val taxYear: String = requestTaxYear
+
+            val response: WSResponse = await(request.put(requestBody))
+            response.status shouldBe expectedStatus
+            response.json shouldBe expectedErrors.fold(Json.toJson(expectedError))(errorWrapper => Json.toJson(errorWrapper))
+            response.header("Content-Type") shouldBe Some("application/json")
+          }
+        }
+
+        val input = Seq(
+          // Path errors
+          ("AA1123A", "2019-20", validRequestJson, BAD_REQUEST, NinoFormatError, None, None),
+          ("AA123456A", "20177", validRequestJson, BAD_REQUEST, TaxYearFormatError, None, None),
+          ("AA123456A", "2015-17", validRequestJson, BAD_REQUEST, RuleTaxYearRangeInvalidError, None, None),
+          ("AA123456A", "2018-19", validRequestJson, BAD_REQUEST, RuleTaxYearNotSupportedError, None, None),
+          ("AA123456A", "2025-26", validRequestJson, BAD_REQUEST, RuleTaxYearForVersionNotSupportedError, None, None),
+
+          // Body errors
+          ("AA123456A", "2021-22", JsObject.empty, BAD_REQUEST, RuleIncorrectOrEmptyBodyError, None, Some("emptyBody")),
+          ("AA123456A", "2021-22", noMeaningfulDataJson, BAD_REQUEST, RuleIncorrectOrEmptyBodyError, None, Some("nonsenseBody")),
+          ("AA123456A", "2021-22", emptyFieldsJson, BAD_REQUEST, emptyFieldsError, None, Some("emptyFields")),
+          ("AA123456A", "2021-22", missingFieldsJson, BAD_REQUEST, missingFieldsError, None, Some("missingFields")),
+          ("AA123456A", "2021-22", gainAndLossJson, BAD_REQUEST, BadRequestError, Some(gainAndLossErrors), Some("gainAndLossRule")),
+          ("AA123456A", "2021-22", decimalsTooBigJson, BAD_REQUEST, BadRequestError, Some(decimalsOutOfRangeErrors), Some("decimalsTooBig")),
+          ("AA123456A", "2021-22", decimalsTooSmallJson, BAD_REQUEST, BadRequestError, Some(decimalsOutOfRangeErrors), Some("decimalsTooSmall")),
+          ("AA123456A", "2021-22", formatDisposalsJson, BAD_REQUEST, BadRequestError, Some(formatDisposalsErrors), Some("formatDisposals")),
+          ("AA123456A", "2021-22", formatNonStandardGainsJson, BAD_REQUEST, formatNonStandardGainsError, None, Some("formatNonStandardGains"))
+        )
+        input.foreach(args => (validationErrorTest).tupled(args))
+      }
+
+      "downstream service error" when {
+        def serviceErrorTest(downstreamStatus: Int, downstreamCode: String, expectedStatus: Int, expectedBody: MtdError): Unit = {
+          s"downstream returns an $downstreamCode error and status $downstreamStatus" in new TysIfsTest {
+
+            override def setupStubs(): Unit = {
+              DownstreamStub.onError(DownstreamStub.PUT, downstreamUrl, downstreamStatus, errorBody(downstreamCode))
+            }
+
+            val response: WSResponse = await(request.put(validRequestJson))
+            response.status shouldBe expectedStatus
+            response.json shouldBe Json.toJson(expectedBody)
+            response.header("Content-Type") shouldBe Some("application/json")
+          }
+        }
+
+        def errorBody(code: String): String =
+          s"""
+             |{
+             |   "code": "$code",
+             |   "reason": "downstream message"
+             |}
+            """.stripMargin
+
+        val errorInput = Seq(
+          (BAD_REQUEST, "INVALID_TAXABLE_ENTITY_ID", BAD_REQUEST, NinoFormatError),
+          (BAD_REQUEST, "INVALID_TAX_YEAR", BAD_REQUEST, TaxYearFormatError),
+          (BAD_REQUEST, "INVALID_PAYLOAD", INTERNAL_SERVER_ERROR, InternalError),
+          (BAD_REQUEST, "INVALID_CORRELATIONID", INTERNAL_SERVER_ERROR, InternalError),
+          (UNPROCESSABLE_ENTITY, "INVALID_DISPOSAL_DATE", BAD_REQUEST, RuleDisposalDateNotFutureError),
+          (UNPROCESSABLE_ENTITY, "INVALID_ACQUISITION_DATE", BAD_REQUEST, RuleAcquisitionDateError),
+          (INTERNAL_SERVER_ERROR, "SERVER_ERROR", INTERNAL_SERVER_ERROR, InternalError),
+          (SERVICE_UNAVAILABLE, "SERVICE_UNAVAILABLE", INTERNAL_SERVER_ERROR, InternalError)
+        )
+
+        val tysErrorInput = Seq(
+          (BAD_REQUEST, "INVALID_CORRELATION_ID", INTERNAL_SERVER_ERROR, InternalError),
+          (UNPROCESSABLE_ENTITY, "TAX_YEAR_NOT_SUPPORTED", BAD_REQUEST, RuleTaxYearNotSupportedError)
+        )
+        (errorInput ++ tysErrorInput).foreach(args => (serviceErrorTest).tupled(args))
+      }
+    }
+  }
+
+}

--- a/it/test/v1/endpoints/DeleteCgtNonPpdControllerHipISpec.scala
+++ b/it/test/v1/endpoints/DeleteCgtNonPpdControllerHipISpec.scala
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v1.endpoints
+
+import play.api.http.HeaderNames.ACCEPT
+import play.api.http.Status.*
+import play.api.libs.json.Json
+import play.api.libs.ws.DefaultBodyReadables.readableAsString
+import play.api.libs.ws.{WSRequest, WSResponse}
+import play.api.test.Helpers.AUTHORIZATION
+import shared.models.errors.*
+import shared.services.*
+import shared.support.IntegrationBaseSpec
+
+class DeleteCgtNonPpdControllerHipISpec extends IntegrationBaseSpec {
+
+  "Calling the 'delete cgt non-ppd disposals' endpoint" should {
+    "return a 204 status code" when {
+
+      "any valid request is made for a Tax Year Specific (TYS) tax year" in new Test {
+
+        override def setupStubs(): Unit = {
+          DownstreamStub.onSuccess(DownstreamStub.DELETE, downstreamUri, NO_CONTENT)
+        }
+
+        val response: WSResponse = await(request().delete())
+        response.status shouldBe NO_CONTENT
+        response.body shouldBe ""
+        response.header("Content-Type") shouldBe None
+        response.header("X-CorrelationId").nonEmpty shouldBe true
+      }
+    }
+
+    "return error according to spec" when {
+
+      "validation error" when {
+        def validationErrorTest(requestNino: String, requestTaxYear: String, expectedStatus: Int, expectedBody: MtdError): Unit = {
+          s"validation fails with ${expectedBody.code} error" in new Test {
+
+            override val nino: String    = requestNino
+            override val taxYear: String = requestTaxYear
+
+            override def setupStubs(): Unit = {}
+
+            val response: WSResponse = await(request().delete())
+            response.status shouldBe expectedStatus
+            response.json shouldBe Json.toJson(expectedBody)
+            response.header("Content-Type") shouldBe Some("application/json")
+          }
+        }
+
+        val input = Seq(
+          ("AA1123A", "2023-24", BAD_REQUEST, NinoFormatError),
+          ("AA123456A", "20199", BAD_REQUEST, TaxYearFormatError),
+          ("AA123456A", "2018-19", BAD_REQUEST, RuleTaxYearNotSupportedError),
+          ("AA123456A", "2025-26", BAD_REQUEST, RuleTaxYearForVersionNotSupportedError),
+          ("AA123456A", "2019-21", BAD_REQUEST, RuleTaxYearRangeInvalidError)
+        )
+        input.foreach(args => validationErrorTest.tupled(args))
+      }
+
+      "downstream service error" when {
+        def serviceErrorTest(downstreamStatus: Int, downstreamCode: String, expectedStatus: Int, expectedBody: MtdError): Unit = {
+          s"downstream returns an $downstreamCode error and status $downstreamStatus" in new Test {
+
+            override def setupStubs(): Unit = {
+              DownstreamStub.onError(DownstreamStub.DELETE, downstreamUri, downstreamStatus, errorBody(downstreamCode))
+            }
+
+            val response: WSResponse = await(request().delete())
+            response.status shouldBe expectedStatus
+            response.json shouldBe Json.toJson(expectedBody)
+            response.header("Content-Type") shouldBe Some("application/json")
+          }
+        }
+
+        def errorBody(`type`: String): String =
+          s"""
+             |{
+             |  "origin": "HoD",
+             |  "response": {
+             |    "failures": [
+             |      {
+             |        "type": "${`type`}",
+             |        "reason": "downstream message"
+             |      }
+             |    ]
+             |  }
+             |}
+        """.stripMargin
+
+        val errors = List(
+          (BAD_REQUEST, "INVALID_TAXABLE_ENTITY_ID", BAD_REQUEST, NinoFormatError),
+          (BAD_REQUEST, "INVALID_TAX_YEAR", BAD_REQUEST, TaxYearFormatError),
+          (BAD_REQUEST, "INVALID_CORRELATION_ID", INTERNAL_SERVER_ERROR, InternalError),
+          (NOT_FOUND, "NOT_FOUND", NOT_FOUND, NotFoundError),
+          (INTERNAL_SERVER_ERROR, "SERVER_ERROR", INTERNAL_SERVER_ERROR, InternalError),
+          (SERVICE_UNAVAILABLE, "SERVICE_UNAVAILABLE", INTERNAL_SERVER_ERROR, InternalError),
+          (UNPROCESSABLE_ENTITY, "TAX_YEAR_NOT_SUPPORTED", BAD_REQUEST, RuleTaxYearNotSupportedError)
+        )
+
+        errors.foreach(args => serviceErrorTest.tupled(args))
+      }
+    }
+  }
+
+  private trait Test {
+
+    val nino: String   = "AA123456A"
+    def mtdUri: String = s"/residential-property/$nino/$taxYear"
+
+    def taxYear: String       = "2023-24"
+    def downstreamUri: String = s"/itsa/income-tax/v1/23-24/income/disposals/residential-property/$nino"
+
+    def setupStubs(): Unit
+
+    def request(): WSRequest = {
+      AuthStub.authorised()
+      MtdIdLookupStub.ninoFound(nino)
+      setupStubs()
+
+      buildRequest(mtdUri)
+        .withHttpHeaders(
+          (ACCEPT, "application/vnd.hmrc.1.0+json"),
+          (AUTHORIZATION, "Bearer 123")
+        )
+    }
+
+  }
+
+}

--- a/it/test/v1/endpoints/DeleteCgtNonPpdControllerIfsISpec.scala
+++ b/it/test/v1/endpoints/DeleteCgtNonPpdControllerIfsISpec.scala
@@ -26,7 +26,10 @@ import shared.models.errors.*
 import shared.services.{AuthStub, DownstreamStub, MtdIdLookupStub}
 import shared.support.IntegrationBaseSpec
 
-class DeleteCgtNonPpdControllerISpec extends IntegrationBaseSpec {
+class DeleteCgtNonPpdControllerIfsISpec extends IntegrationBaseSpec {
+
+  override def servicesConfig: Map[String, Any] =
+    Map("feature-switch.ifs_hip_migration_1875.enabled" -> false) ++ super.servicesConfig
 
   "Calling the 'delete cgt non-ppd disposals' endpoint" should {
     "return a 204 status code" when {
@@ -79,9 +82,10 @@ class DeleteCgtNonPpdControllerISpec extends IntegrationBaseSpec {
           ("AA1123A", "2019-20", BAD_REQUEST, NinoFormatError),
           ("AA123456A", "20199", BAD_REQUEST, TaxYearFormatError),
           ("AA123456A", "2018-19", BAD_REQUEST, RuleTaxYearNotSupportedError),
+          ("AA123456A", "2025-26", BAD_REQUEST, RuleTaxYearForVersionNotSupportedError),
           ("AA123456A", "2019-21", BAD_REQUEST, RuleTaxYearRangeInvalidError)
         )
-        input.foreach(args => (validationErrorTest).tupled(args))
+        input.foreach(args => validationErrorTest.tupled(args))
       }
 
       "downstream service error" when {
@@ -122,7 +126,7 @@ class DeleteCgtNonPpdControllerISpec extends IntegrationBaseSpec {
           (UNPROCESSABLE_ENTITY, "TAX_YEAR_NOT_SUPPORTED", BAD_REQUEST, RuleTaxYearNotSupportedError)
         )
 
-        (errors ++ extraTysErrors).foreach(args => (serviceErrorTest).tupled(args))
+        (errors ++ extraTysErrors).foreach(args => serviceErrorTest.tupled(args))
       }
     }
   }

--- a/it/test/v1/endpoints/DeleteCgtPpdOverridesControllerHipISpec.scala
+++ b/it/test/v1/endpoints/DeleteCgtPpdOverridesControllerHipISpec.scala
@@ -1,0 +1,180 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v1.endpoints
+
+import com.github.tomakehurst.wiremock.stubbing.StubMapping
+import play.api.http.HeaderNames.ACCEPT
+import play.api.http.Status.*
+import play.api.libs.json.Json
+import play.api.libs.ws.DefaultBodyReadables.readableAsString
+import play.api.libs.ws.{WSRequest, WSResponse}
+import play.api.test.Helpers.AUTHORIZATION
+import shared.models.errors.*
+import shared.services.*
+import shared.support.IntegrationBaseSpec
+
+class DeleteCgtPpdOverridesControllerHipISpec extends IntegrationBaseSpec {
+
+  override def servicesConfig: Map[String, Any] =
+    Map("feature-switch.ifs_hip_migration_1947.enabled" -> true) ++ super.servicesConfig
+
+  private trait Test {
+
+    val nino: String = "AA123456A"
+
+    def taxYear: String
+    def downstreamUri: String
+
+    def uri: String = s"/residential-property/$nino/$taxYear/ppd"
+
+    def setupStubs(): StubMapping
+
+    def request(): WSRequest = {
+      setupStubs()
+      buildRequest(uri)
+        .withHttpHeaders(
+          (ACCEPT, "application/vnd.hmrc.1.0+json"),
+          (AUTHORIZATION, "Bearer 123") // some bearer token
+        )
+    }
+
+  }
+
+  private trait NonTysTest extends Test {
+    def taxYear: String       = "2019-20"
+    def downstreamUri: String = s"/income-tax/income/disposals/residential-property/ppd/$nino/$taxYear"
+  }
+
+  private trait TysHipTest extends Test {
+    def taxYear: String       = "2023-24"
+    def downstreamUri: String = s"/itsa/income-tax/v1/23-24/income/disposals/residential-property/ppd/$nino"
+  }
+
+  "Calling the 'delete cgt ppd overrides' endpoint" should {
+    "return a 204 status code" when {
+      "any valid request is made" in new NonTysTest {
+
+        override def setupStubs(): StubMapping = {
+          AuthStub.authorised()
+          MtdIdLookupStub.ninoFound(nino)
+          DownstreamStub.onSuccess(DownstreamStub.DELETE, downstreamUri, NO_CONTENT)
+        }
+
+        val response: WSResponse = await(request().delete())
+        response.status shouldBe NO_CONTENT
+        response.body shouldBe ""
+        response.header("Content-Type") shouldBe None
+        response.header("X-CorrelationId").nonEmpty shouldBe true
+      }
+
+      "any valid request is made for a Tax Year Specific (TYS) tax year" in new TysHipTest {
+
+        override def setupStubs(): StubMapping = {
+          AuthStub.authorised()
+          MtdIdLookupStub.ninoFound(nino)
+          DownstreamStub.onSuccess(DownstreamStub.DELETE, downstreamUri, NO_CONTENT)
+        }
+
+        val response: WSResponse = await(request().delete())
+        response.status shouldBe NO_CONTENT
+        response.body shouldBe ""
+        response.header("Content-Type") shouldBe None
+        response.header("X-CorrelationId").nonEmpty shouldBe true
+      }
+    }
+
+    "return error according to spec" when {
+
+      "validation error" when {
+        def validationErrorTest(requestNino: String, requestTaxYear: String, expectedStatus: Int, expectedBody: MtdError): Unit = {
+          s"validation fails with ${expectedBody.code} error" in new NonTysTest {
+
+            override val nino: String    = requestNino
+            override val taxYear: String = requestTaxYear
+
+            override def setupStubs(): StubMapping = {
+              AuthStub.authorised()
+              MtdIdLookupStub.ninoFound(nino)
+            }
+
+            val response: WSResponse = await(request().delete())
+            response.status shouldBe expectedStatus
+            response.json shouldBe Json.toJson(expectedBody)
+            response.header("Content-Type") shouldBe Some("application/json")
+          }
+        }
+
+        val input = Seq(
+          ("AA1123A", "2019-20", BAD_REQUEST, NinoFormatError),
+          ("AA123456A", "20199", BAD_REQUEST, TaxYearFormatError),
+          ("AA123456A", "2018-19", BAD_REQUEST, RuleTaxYearNotSupportedError),
+          ("AA123456A", "2025-26", BAD_REQUEST, RuleTaxYearForVersionNotSupportedError),
+          ("AA123456A", "2019-21", BAD_REQUEST, RuleTaxYearRangeInvalidError)
+        )
+        input.foreach(args => (validationErrorTest).tupled(args))
+      }
+
+      "downstream service error" when {
+        def serviceErrorTest(downstreamStatus: Int, downstreamCode: String, expectedStatus: Int, expectedBody: MtdError): Unit = {
+          s"downstream returns an $downstreamCode error and status $downstreamStatus" in new NonTysTest {
+
+            override def setupStubs(): StubMapping = {
+              AuthStub.authorised()
+              MtdIdLookupStub.ninoFound(nino)
+              DownstreamStub.onError(DownstreamStub.DELETE, downstreamUri, downstreamStatus, errorBody(downstreamCode))
+            }
+
+            val response: WSResponse = await(request().delete())
+            response.status shouldBe expectedStatus
+            response.json shouldBe Json.toJson(expectedBody)
+            response.header("Content-Type") shouldBe Some("application/json")
+          }
+        }
+
+        def errorBody(code: String): String =
+          s"""
+             |{
+             |  "origin": "HoD",
+             |  "response": {
+             |    "failures": [
+             |      {
+             |        "type": "$code",
+             |        "reason": "message"
+             |      }
+             |    ]
+             |  }
+             |}
+            """.stripMargin
+
+        val errors = Seq(
+          (BAD_REQUEST, "INVALID_TAXABLE_ENTITY_ID", BAD_REQUEST, NinoFormatError),
+          (BAD_REQUEST, "INVALID_TAX_YEAR", BAD_REQUEST, TaxYearFormatError),
+          (BAD_REQUEST, "INVALID_CORRELATIONID", INTERNAL_SERVER_ERROR, InternalError),
+          (NOT_FOUND, "NO_DATA_FOUND", NOT_FOUND, NotFoundError),
+          (INTERNAL_SERVER_ERROR, "SERVER_ERROR", INTERNAL_SERVER_ERROR, InternalError),
+          (SERVICE_UNAVAILABLE, "SERVICE_UNAVAILABLE", INTERNAL_SERVER_ERROR, InternalError)
+        )
+        val extraTysErrors = Seq(
+          (UNPROCESSABLE_ENTITY, "TAX_YEAR_NOT_SUPPORTED", BAD_REQUEST, RuleTaxYearNotSupportedError)
+        )
+
+        (errors ++ extraTysErrors).foreach(args => (serviceErrorTest).tupled(args))
+      }
+    }
+  }
+
+}

--- a/it/test/v1/endpoints/DeleteCgtPpdOverridesControllerIfsISpec.scala
+++ b/it/test/v1/endpoints/DeleteCgtPpdOverridesControllerIfsISpec.scala
@@ -27,7 +27,10 @@ import shared.models.errors.*
 import shared.services.*
 import shared.support.IntegrationBaseSpec
 
-class DeleteCgtPpdOverridesControllerISpec extends IntegrationBaseSpec {
+class DeleteCgtPpdOverridesControllerIfsISpec extends IntegrationBaseSpec {
+
+  override def servicesConfig: Map[String, Any] =
+    Map("feature-switch.ifs_hip_migration_1947.enabled" -> false) ++ super.servicesConfig
 
   private trait Test {
 
@@ -119,6 +122,7 @@ class DeleteCgtPpdOverridesControllerISpec extends IntegrationBaseSpec {
           ("AA1123A", "2019-20", BAD_REQUEST, NinoFormatError),
           ("AA123456A", "20199", BAD_REQUEST, TaxYearFormatError),
           ("AA123456A", "2018-19", BAD_REQUEST, RuleTaxYearNotSupportedError),
+          ("AA123456A", "2025-26", BAD_REQUEST, RuleTaxYearForVersionNotSupportedError),
           ("AA123456A", "2019-21", BAD_REQUEST, RuleTaxYearRangeInvalidError)
         )
         input.foreach(args => (validationErrorTest).tupled(args))

--- a/it/test/v1/endpoints/DeleteOtherCgtControllerHipISpec.scala
+++ b/it/test/v1/endpoints/DeleteOtherCgtControllerHipISpec.scala
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v1.endpoints
+
+import com.github.tomakehurst.wiremock.stubbing.StubMapping
+import play.api.http.HeaderNames.ACCEPT
+import play.api.http.Status.*
+import play.api.libs.json.Json
+import play.api.libs.ws.DefaultBodyReadables.readableAsString
+import play.api.libs.ws.{WSRequest, WSResponse}
+import play.api.test.Helpers.AUTHORIZATION
+import shared.models.errors.*
+import shared.services.*
+import shared.support.IntegrationBaseSpec
+
+class DeleteOtherCgtControllerHipISpec extends IntegrationBaseSpec {
+
+  override def servicesConfig: Map[String, Any] =
+    Map("feature-switch.ifs_hip_migration_1953.enabled" -> true) ++ super.servicesConfig
+
+  "Calling the 'delete other capital gains and disposals' endpoint" should {
+    "return a 204 status code" when {
+      "any valid request is made using HIP" in new Test {
+
+        override def setupStubs(): StubMapping = {
+          AuthStub.authorised()
+          MtdIdLookupStub.ninoFound(nino)
+          DownstreamStub.onSuccess(DownstreamStub.DELETE, downstreamUri, NO_CONTENT)
+        }
+
+        val response: WSResponse = await(request().delete())
+        response.status shouldBe NO_CONTENT
+        response.body shouldBe ""
+        response.header("Content-Type") shouldBe None
+        response.header("X-CorrelationId").nonEmpty shouldBe true
+      }
+    }
+
+    "return error according to spec" when {
+
+      "validation error" when {
+        def validationErrorTest(requestNino: String, requestTaxYear: String, expectedStatus: Int, expectedBody: MtdError): Unit = {
+          s"validation fails with ${expectedBody.code} error" in new Test {
+
+            override val nino: String    = requestNino
+            override val taxYear: String = requestTaxYear
+
+            override def setupStubs(): StubMapping = {
+              AuthStub.authorised()
+              MtdIdLookupStub.ninoFound(nino)
+            }
+
+            val response: WSResponse = await(request().delete())
+            response.status shouldBe expectedStatus
+            response.json shouldBe Json.toJson(expectedBody)
+            response.header("Content-Type") shouldBe Some("application/json")
+          }
+        }
+
+        val input = Seq(
+          ("AA1123A", "2019-20", BAD_REQUEST, NinoFormatError),
+          ("AA123456A", "20199", BAD_REQUEST, TaxYearFormatError),
+          ("AA123456A", "2018-19", BAD_REQUEST, RuleTaxYearNotSupportedError),
+          ("AA123456A", "2019-21", BAD_REQUEST, RuleTaxYearRangeInvalidError),
+          ("AA123456A", "2025-26", BAD_REQUEST, RuleTaxYearForVersionNotSupportedError)
+        )
+        input.foreach(args => (validationErrorTest).tupled(args))
+      }
+
+      "downstream service error" when {
+        def serviceErrorTest(downstreamStatus: Int, downstreamCode: String, expectedStatus: Int, expectedBody: MtdError): Unit = {
+          s"downstream returns an $downstreamCode error and status $downstreamStatus" in new Test {
+
+            override def setupStubs(): StubMapping = {
+              AuthStub.authorised()
+              MtdIdLookupStub.ninoFound(nino)
+              DownstreamStub.onError(DownstreamStub.DELETE, downstreamUri, downstreamStatus, errorBody(downstreamCode))
+            }
+
+            val response: WSResponse = await(request().delete())
+            response.status shouldBe expectedStatus
+            response.json shouldBe Json.toJson(expectedBody)
+            response.header("Content-Type") shouldBe Some("application/json")
+          }
+        }
+
+        def errorBody(`type`: String): String =
+          s"""
+             |{
+             |  "origin": "HoD",
+             |  "response": {
+             |    "failures": [
+             |      {
+             |        "type": "${`type`}",
+             |        "reason": "downstream message"
+             |      }
+             |    ]
+             |  }
+             |}
+               """.stripMargin
+
+        val errors = Seq(
+          (BAD_REQUEST, "INVALID_TAXABLE_ENTITY_ID", BAD_REQUEST, NinoFormatError),
+          (BAD_REQUEST, "INVALID_TAX_YEAR", BAD_REQUEST, TaxYearFormatError),
+          (BAD_REQUEST, "INVALID_CORRELATIONID", INTERNAL_SERVER_ERROR, InternalError),
+          (NOT_FOUND, "NO_DATA_FOUND", NOT_FOUND, NotFoundError),
+          (INTERNAL_SERVER_ERROR, "SERVER_ERROR", INTERNAL_SERVER_ERROR, InternalError),
+          (SERVICE_UNAVAILABLE, "SERVICE_UNAVAILABLE", INTERNAL_SERVER_ERROR, InternalError)
+        )
+
+        val extraTysErrors = Seq(
+          (BAD_REQUEST, "INVALID_CORRELATION_ID", INTERNAL_SERVER_ERROR, InternalError),
+          (NOT_FOUND, "NOT_FOUND", NOT_FOUND, NotFoundError),
+          (UNPROCESSABLE_ENTITY, "TAX_YEAR_NOT_SUPPORTED", BAD_REQUEST, RuleTaxYearNotSupportedError)
+        )
+
+        (errors ++ extraTysErrors).foreach(args => (serviceErrorTest).tupled(args))
+      }
+    }
+  }
+
+  private trait Test {
+
+    val nino: String = "AA123456A"
+
+    def taxYear: String                   = "2023-24"
+    private def taxYearDownstream: String = "23-24"
+
+    private def mtdUri: String = s"/other-gains/$nino/$taxYear"
+    def downstreamUri: String  = s"/itsa/income-tax/v1/$taxYearDownstream/income/disposals/other-gains/$nino"
+
+    def setupStubs(): StubMapping
+
+    def request(): WSRequest = {
+      setupStubs()
+      buildRequest(mtdUri)
+        .withHttpHeaders(
+          (ACCEPT, "application/vnd.hmrc.1.0+json"),
+          (AUTHORIZATION, "Bearer 123") // some bearer token
+        )
+    }
+
+  }
+
+}

--- a/it/test/v1/endpoints/DeleteOtherCgtControllerIfsISpec.scala
+++ b/it/test/v1/endpoints/DeleteOtherCgtControllerIfsISpec.scala
@@ -1,0 +1,175 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v1.endpoints
+
+import com.github.tomakehurst.wiremock.stubbing.StubMapping
+import play.api.http.HeaderNames.ACCEPT
+import play.api.http.Status.*
+import play.api.libs.json.Json
+import play.api.libs.ws.DefaultBodyReadables.readableAsString
+import play.api.libs.ws.{WSRequest, WSResponse}
+import play.api.test.Helpers.AUTHORIZATION
+import shared.models.errors.*
+import shared.services.*
+import shared.support.IntegrationBaseSpec
+
+class DeleteOtherCgtControllerIfsISpec extends IntegrationBaseSpec {
+
+  override def servicesConfig: Map[String, Any] =
+    Map("feature-switch.ifs_hip_migration_1953.enabled" -> false) ++ super.servicesConfig
+
+  "Calling the 'delete other capital gains and disposals' endpoint" should {
+    "return a 204 status code" when {
+      "any valid request is made using IFS" in new NonTysTest with Test {
+
+        override def setupStubs(): StubMapping = {
+          AuthStub.authorised()
+          MtdIdLookupStub.ninoFound(nino)
+          DownstreamStub.onSuccess(DownstreamStub.DELETE, downstreamUri, NO_CONTENT)
+        }
+
+        val response: WSResponse = await(request().delete())
+        response.status shouldBe NO_CONTENT
+        response.body shouldBe ""
+        response.header("Content-Type") shouldBe None
+        response.header("X-CorrelationId").nonEmpty shouldBe true
+      }
+
+      "any valid request with a Tax Year Specific (TYS) tax year is made" in new TysIfsTest with Test {
+
+        override def setupStubs(): StubMapping = {
+          AuthStub.authorised()
+          MtdIdLookupStub.ninoFound(nino)
+          DownstreamStub.onSuccess(DownstreamStub.DELETE, downstreamUri, NO_CONTENT)
+        }
+
+        val response: WSResponse = await(request().delete())
+        response.status shouldBe NO_CONTENT
+        response.body shouldBe ""
+        response.header("Content-Type") shouldBe None
+        response.header("X-CorrelationId").nonEmpty shouldBe true
+      }
+    }
+
+    "return error according to spec" when {
+
+      "validation error" when {
+        def validationErrorTest(requestNino: String, requestTaxYear: String, expectedStatus: Int, expectedBody: MtdError): Unit = {
+          s"validation fails with ${expectedBody.code} error" in new NonTysTest with Test {
+
+            override val nino: String    = requestNino
+            override val taxYear: String = requestTaxYear
+
+            override def setupStubs(): StubMapping = {
+              AuthStub.authorised()
+              MtdIdLookupStub.ninoFound(nino)
+            }
+
+            val response: WSResponse = await(request().delete())
+            response.status shouldBe expectedStatus
+            response.json shouldBe Json.toJson(expectedBody)
+            response.header("Content-Type") shouldBe Some("application/json")
+          }
+        }
+
+        val input = Seq(
+          ("AA1123A", "2019-20", BAD_REQUEST, NinoFormatError),
+          ("AA123456A", "20199", BAD_REQUEST, TaxYearFormatError),
+          ("AA123456A", "2018-19", BAD_REQUEST, RuleTaxYearNotSupportedError),
+          ("AA123456A", "2019-21", BAD_REQUEST, RuleTaxYearRangeInvalidError),
+          ("AA123456A", "2025-26", BAD_REQUEST, RuleTaxYearForVersionNotSupportedError)
+        )
+        input.foreach(args => (validationErrorTest).tupled(args))
+      }
+
+      "downstream service error" when {
+        def serviceErrorTest(downstreamStatus: Int, downstreamCode: String, expectedStatus: Int, expectedBody: MtdError): Unit = {
+          s"downstream returns an $downstreamCode error and status $downstreamStatus" in new NonTysTest with Test {
+
+            override def setupStubs(): StubMapping = {
+              AuthStub.authorised()
+              MtdIdLookupStub.ninoFound(nino)
+              DownstreamStub.onError(DownstreamStub.DELETE, downstreamUri, downstreamStatus, errorBody(downstreamCode))
+            }
+
+            val response: WSResponse = await(request().delete())
+            response.status shouldBe expectedStatus
+            response.json shouldBe Json.toJson(expectedBody)
+            response.header("Content-Type") shouldBe Some("application/json")
+          }
+        }
+
+        def errorBody(code: String): String =
+          s"""
+             |{
+             |   "code": "$code",
+             |   "reason": "downstream message"
+             |}
+            """.stripMargin
+
+        val errors = Seq(
+          (BAD_REQUEST, "INVALID_TAXABLE_ENTITY_ID", BAD_REQUEST, NinoFormatError),
+          (BAD_REQUEST, "INVALID_TAX_YEAR", BAD_REQUEST, TaxYearFormatError),
+          (BAD_REQUEST, "INVALID_CORRELATIONID", INTERNAL_SERVER_ERROR, InternalError),
+          (NOT_FOUND, "NO_DATA_FOUND", NOT_FOUND, NotFoundError),
+          (INTERNAL_SERVER_ERROR, "SERVER_ERROR", INTERNAL_SERVER_ERROR, InternalError),
+          (SERVICE_UNAVAILABLE, "SERVICE_UNAVAILABLE", INTERNAL_SERVER_ERROR, InternalError)
+        )
+
+        val extraTysErrors = Seq(
+          (BAD_REQUEST, "INVALID_CORRELATION_ID", INTERNAL_SERVER_ERROR, InternalError),
+          (NOT_FOUND, "NOT_FOUND", NOT_FOUND, NotFoundError),
+          (UNPROCESSABLE_ENTITY, "TAX_YEAR_NOT_SUPPORTED", BAD_REQUEST, RuleTaxYearNotSupportedError)
+        )
+
+        (errors ++ extraTysErrors).foreach(args => (serviceErrorTest).tupled(args))
+      }
+    }
+  }
+
+  private trait Test {
+
+    val nino: String = "AA123456A"
+
+    def taxYear: String
+    def mtdUri: String = s"/other-gains/$nino/$taxYear"
+    def downstreamUri: String
+
+    def setupStubs(): StubMapping
+
+    def request(): WSRequest = {
+      setupStubs()
+      buildRequest(mtdUri)
+        .withHttpHeaders(
+          (ACCEPT, "application/vnd.hmrc.1.0+json"),
+          (AUTHORIZATION, "Bearer 123") // some bearer token
+        )
+    }
+
+  }
+
+  private trait NonTysTest extends Test {
+    def taxYear: String       = "2019-20"
+    def downstreamUri: String = s"/income-tax/income/disposals/other-gains/$nino/2019-20"
+  }
+
+  private trait TysIfsTest extends Test {
+    def taxYear: String       = "2023-24"
+    def downstreamUri: String = s"/income-tax/income/disposals/other-gains/23-24/$nino"
+  }
+
+}

--- a/it/test/v1/endpoints/RetrieveAllResidentialPropertyCgtControllerHipISpec.scala
+++ b/it/test/v1/endpoints/RetrieveAllResidentialPropertyCgtControllerHipISpec.scala
@@ -1,0 +1,185 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v1.endpoints
+
+import com.github.tomakehurst.wiremock.stubbing.StubMapping
+import common.errors.SourceFormatError
+import play.api.http.HeaderNames.ACCEPT
+import play.api.http.Status.*
+import play.api.libs.json.{JsValue, Json}
+import play.api.libs.ws.{WSRequest, WSResponse}
+import play.api.test.Helpers.AUTHORIZATION
+import shared.models.errors.*
+import shared.services.*
+import shared.support.IntegrationBaseSpec
+import v1.residentialPropertyDisposals.retrieveAll.def1.fixture.Def1_RetrieveAllResidentialPropertyCgtControllerFixture
+
+class RetrieveAllResidentialPropertyCgtControllerHipISpec extends IntegrationBaseSpec {
+
+  private trait Test {
+
+    def nino: String           = "AA123456A"
+    def source: Option[String] = Some("latest")
+
+    def taxYear: String
+
+    def downstreamUri: String
+    val downstreamResponse: JsValue = Def1_RetrieveAllResidentialPropertyCgtControllerFixture.ifsJson
+
+    def mtdUri: String       = s"/residential-property/$nino/$taxYear"
+    val mtdResponse: JsValue = Def1_RetrieveAllResidentialPropertyCgtControllerFixture.mtdJson
+
+    def mtdQueryParams: Seq[(String, String)] =
+      Seq("source" -> source)
+        .collect { case (k, Some(v)) =>
+          (k, v)
+        }
+
+    def setupStubs(): StubMapping
+
+    def mtdRequest: WSRequest = {
+      setupStubs()
+      buildRequest(mtdUri)
+        .addQueryStringParameters(mtdQueryParams*)
+        .withHttpHeaders(
+          (ACCEPT, "application/vnd.hmrc.1.0+json"),
+          (AUTHORIZATION, "Bearer 123") // some bearer token
+        )
+    }
+
+  }
+
+  private trait TysHipTest extends Test {
+    def taxYear: String       = "2023-24"
+    def downstreamUri: String = s"/itsa/income-tax/v1/23-24/income/disposals/residential-property/$nino"
+  }
+
+  "Calling the 'retrieve all residential property cgt' endpoint" should {
+    "return a 200 status code" when {
+
+      "any valid request is made for Tax Year Specific (TYS)" in new TysHipTest {
+
+        override def setupStubs(): StubMapping = {
+          AuditStub.audit()
+          AuthStub.authorised()
+          MtdIdLookupStub.ninoFound(nino)
+          DownstreamStub.onSuccess(DownstreamStub.GET, downstreamUri, Map("view" -> "LATEST"), OK, downstreamResponse)
+        }
+
+        val response: WSResponse = await(mtdRequest.get())
+        response.status shouldBe OK
+        response.json shouldBe mtdResponse
+        response.header("Content-Type") shouldBe Some("application/json")
+      }
+
+      "any valid request is made without source" in new TysHipTest {
+        override def source: Option[String] = None
+
+        override def setupStubs(): StubMapping = {
+          AuditStub.audit()
+          AuthStub.authorised()
+          MtdIdLookupStub.ninoFound(nino)
+          DownstreamStub.onSuccess(DownstreamStub.GET, downstreamUri, Map("view" -> "LATEST"), OK, downstreamResponse)
+        }
+
+        val response: WSResponse = await(mtdRequest.get())
+        response.status shouldBe OK
+        response.json shouldBe mtdResponse
+        response.header("Content-Type") shouldBe Some("application/json")
+      }
+    }
+
+    "return error according to spec" when {
+
+      "validation error" when {
+        def validationErrorTest(requestNino: String,
+                                requestTaxYear: String,
+                                requestSource: String,
+                                expectedStatus: Int,
+                                expectedBody: MtdError): Unit = {
+          s"validation fails with ${expectedBody.code} error" in new TysHipTest {
+
+            override val nino: String           = requestNino
+            override val taxYear: String        = requestTaxYear
+            override val source: Option[String] = Some(requestSource)
+
+            override def setupStubs(): StubMapping = {
+              AuditStub.audit()
+              AuthStub.authorised()
+              MtdIdLookupStub.ninoFound(nino)
+            }
+
+            val response: WSResponse = await(mtdRequest.get())
+            response.status shouldBe expectedStatus
+            response.json shouldBe Json.toJson(expectedBody)
+            response.header("Content-Type") shouldBe Some("application/json")
+          }
+        }
+
+        val input = Seq(
+          ("AA1123A", "2019-20", "latest", BAD_REQUEST, NinoFormatError),
+          ("AA123456A", "20177", "latest", BAD_REQUEST, TaxYearFormatError),
+          ("AA123456A", "2015-17", "latest", BAD_REQUEST, RuleTaxYearRangeInvalidError),
+          ("AA123456A", "2015-16", "latest", BAD_REQUEST, RuleTaxYearNotSupportedError),
+          ("AA123456A", "2025-26", "latest", BAD_REQUEST, RuleTaxYearForVersionNotSupportedError),
+          ("AA123456A", "2019-20", "test", BAD_REQUEST, SourceFormatError)
+        )
+        input.foreach(args => (validationErrorTest).tupled(args))
+      }
+
+      "downstream service error" when {
+        def serviceErrorTest(downstreamStatus: Int, downstreamCode: String, expectedStatus: Int, expectedBody: MtdError): Unit = {
+          s"downstream returns an $downstreamCode error and status $downstreamStatus" in new TysHipTest {
+
+            override def setupStubs(): StubMapping = {
+              AuditStub.audit()
+              AuthStub.authorised()
+              MtdIdLookupStub.ninoFound(nino)
+              DownstreamStub.onError(DownstreamStub.GET, downstreamUri, Map("view" -> "LATEST"), downstreamStatus, errorBody(downstreamCode))
+            }
+
+            val response: WSResponse = await(mtdRequest.get())
+            response.status shouldBe expectedStatus
+            response.json shouldBe Json.toJson(expectedBody)
+            response.header("Content-Type") shouldBe Some("application/json")
+          }
+        }
+
+        def errorBody(code: String): String =
+          s"""
+             |{
+             |   "code": "$code",
+             |   "reason": "downstream message"
+             |}
+            """.stripMargin
+
+        val input = Seq(
+          (BAD_REQUEST, "INVALID_TAXABLE_ENTITY_ID", BAD_REQUEST, NinoFormatError),
+          (BAD_REQUEST, "INVALID_TAX_YEAR", BAD_REQUEST, TaxYearFormatError),
+          (BAD_REQUEST, "INVALID_VIEW", BAD_REQUEST, SourceFormatError),
+          (UNPROCESSABLE_ENTITY, "TAX_YEAR_NOT_SUPPORTED", BAD_REQUEST, RuleTaxYearNotSupportedError),
+          (BAD_REQUEST, "INVALID_CORRELATIONID", INTERNAL_SERVER_ERROR, InternalError),
+          (NOT_FOUND, "NO_DATA_FOUND", NOT_FOUND, NotFoundError),
+          (INTERNAL_SERVER_ERROR, "SERVER_ERROR", INTERNAL_SERVER_ERROR, InternalError),
+          (SERVICE_UNAVAILABLE, "SERVICE_UNAVAILABLE", INTERNAL_SERVER_ERROR, InternalError)
+        )
+        input.foreach(args => (serviceErrorTest).tupled(args))
+      }
+    }
+  }
+
+}

--- a/it/test/v1/endpoints/RetrieveAllResidentialPropertyCgtControllerIfsISpec.scala
+++ b/it/test/v1/endpoints/RetrieveAllResidentialPropertyCgtControllerIfsISpec.scala
@@ -28,7 +28,10 @@ import shared.services.*
 import shared.support.IntegrationBaseSpec
 import v1.residentialPropertyDisposals.retrieveAll.def1.fixture.Def1_RetrieveAllResidentialPropertyCgtControllerFixture
 
-class RetrieveAllResidentialPropertyCgtControllerISpec extends IntegrationBaseSpec {
+class RetrieveAllResidentialPropertyCgtControllerIfsISpec extends IntegrationBaseSpec {
+
+  override def servicesConfig: Map[String, Any] =
+    super.servicesConfig ++ Map("feature-switch.ifs_hip_migration_1881.enabled" -> false)
 
   private trait Test {
 
@@ -154,6 +157,7 @@ class RetrieveAllResidentialPropertyCgtControllerISpec extends IntegrationBaseSp
           ("AA123456A", "20177", "latest", BAD_REQUEST, TaxYearFormatError),
           ("AA123456A", "2015-17", "latest", BAD_REQUEST, RuleTaxYearRangeInvalidError),
           ("AA123456A", "2015-16", "latest", BAD_REQUEST, RuleTaxYearNotSupportedError),
+          ("AA123456A", "2025-26", "latest", BAD_REQUEST, RuleTaxYearForVersionNotSupportedError),
           ("AA123456A", "2019-20", "test", BAD_REQUEST, SourceFormatError)
         )
         input.foreach(args => (validationErrorTest).tupled(args))

--- a/it/test/v1/endpoints/RetrieveOtherCgtControllerIfsISpec.scala
+++ b/it/test/v1/endpoints/RetrieveOtherCgtControllerIfsISpec.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package v2.endpoints
+package v1.endpoints
 
 import com.github.tomakehurst.wiremock.stubbing.StubMapping
 import play.api.http.HeaderNames.ACCEPT
@@ -26,7 +26,10 @@ import shared.models.errors.*
 import shared.services.*
 import shared.support.IntegrationBaseSpec
 
-class RetrieveOtherCgtControllerISpec extends IntegrationBaseSpec {
+class RetrieveOtherCgtControllerIfsISpec extends IntegrationBaseSpec {
+
+  override def servicesConfig: Map[String, Any] =
+    Map("feature-switch.ifs_hip_migration_1951.enabled" -> false) ++ super.servicesConfig
 
   "Calling the 'retrieve other CGT' endpoint" should {
     "return a 200 status code" when {
@@ -86,7 +89,8 @@ class RetrieveOtherCgtControllerISpec extends IntegrationBaseSpec {
           ("AA1123A", "2019-20", BAD_REQUEST, NinoFormatError),
           ("AA123456A", "20177", BAD_REQUEST, TaxYearFormatError),
           ("AA123456A", "2015-17", BAD_REQUEST, RuleTaxYearRangeInvalidError),
-          ("AA123456A", "2018-19", BAD_REQUEST, RuleTaxYearNotSupportedError)
+          ("AA123456A", "2018-19", BAD_REQUEST, RuleTaxYearNotSupportedError),
+          ("AA123456A", "2025-26", BAD_REQUEST, RuleTaxYearForVersionNotSupportedError)
         )
         input.foreach(args => (validationErrorTest).tupled(args))
       }
@@ -228,7 +232,7 @@ class RetrieveOtherCgtControllerISpec extends IntegrationBaseSpec {
       setupStubs()
       buildRequest(uri)
         .withHttpHeaders(
-          (ACCEPT, "application/vnd.hmrc.2.0+json"),
+          (ACCEPT, "application/vnd.hmrc.1.0+json"),
           (AUTHORIZATION, "Bearer 123") // some bearer token
         )
     }

--- a/it/test/v2/endpoints/CreateAmendCgtPpdOverridesControllerIfsISpec.scala
+++ b/it/test/v2/endpoints/CreateAmendCgtPpdOverridesControllerIfsISpec.scala
@@ -1,0 +1,534 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v2.endpoints
+
+import com.github.tomakehurst.wiremock.client.WireMock.*
+import com.github.tomakehurst.wiremock.stubbing.StubMapping
+import common.errors.*
+import play.api.http.HeaderNames.ACCEPT
+import play.api.http.Status.*
+import play.api.libs.json.{JsObject, JsValue, Json}
+import play.api.libs.ws.WSBodyWritables.writeableOf_JsValue
+import play.api.libs.ws.{WSRequest, WSResponse}
+import play.api.test.Helpers.AUTHORIZATION
+import shared.models.errors.*
+import shared.services.*
+import shared.support.{IntegrationBaseSpec, WireMockMethods}
+
+class CreateAmendCgtPpdOverridesControllerIfsISpec extends IntegrationBaseSpec with WireMockMethods {
+
+  override def servicesConfig: Map[String, Any] =
+    Map("feature-switch.ifs_hip_migration_1946.enabled" -> false) ++ super.servicesConfig
+
+  val validRequestBodyJson: JsValue = Json.parse(
+    """
+      |{
+      |    "multiplePropertyDisposals": [
+      |         {
+      |            "ppdSubmissionId": "AB0000000092",
+      |            "amountOfNetGain": 1234.78
+      |         },
+      |         {
+      |            "ppdSubmissionId": "AB0000000098",
+      |            "amountOfNetLoss": 134.99
+      |         }
+      |    ],
+      |    "singlePropertyDisposals": [
+      |         {
+      |             "ppdSubmissionId": "AB0000000099",
+      |             "completionDate": "2020-02-28",
+      |             "disposalProceeds": 454.24,
+      |             "acquisitionDate": "2020-03-29",
+      |             "acquisitionAmount": 3434.45,
+      |             "improvementCosts": 233.45,
+      |             "additionalCosts": 423.34,
+      |             "prfAmount": 2324.67,
+      |             "otherReliefAmount": 3434.23,
+      |             "lossesFromThisYear": 436.23,
+      |             "lossesFromPreviousYear": 234.23,
+      |             "amountOfNetGain": 4567.89
+      |         },
+      |         {
+      |             "ppdSubmissionId": "AB0000000091",
+      |             "completionDate": "2020-02-28",
+      |             "disposalProceeds": 454.24,
+      |             "acquisitionDate": "2020-03-29",
+      |             "acquisitionAmount": 3434.45,
+      |             "improvementCosts": 233.45,
+      |             "additionalCosts": 423.34,
+      |             "prfAmount": 2324.67,
+      |             "otherReliefAmount": 3434.23,
+      |             "lossesFromThisYear": 436.23,
+      |             "lossesFromPreviousYear": 234.23,
+      |             "amountOfNetLoss": 4567.89
+      |         }
+      |    ]
+      |}
+      |""".stripMargin
+  )
+
+  val nonsenseBodyJson: JsValue = Json.parse(
+    """
+      |{
+      |  "aField": "aValue"
+      |}
+       """.stripMargin
+  )
+
+  val emptyFieldsJson: JsValue = Json.parse(
+    """
+      |{
+      |   "multiplePropertyDisposals": [],
+      |   "singlePropertyDisposals": []
+      |}
+     """.stripMargin
+  )
+
+  val emptyFieldsError: MtdError = RuleIncorrectOrEmptyBodyError.copy(
+    paths = Some(
+      Seq(
+        "/multiplePropertyDisposals",
+        "/singlePropertyDisposals"
+      ))
+  )
+
+  val missingFieldsJson: JsValue = Json.parse(
+    """
+      |{
+      |   "multiplePropertyDisposals": [{}],
+      |   "singlePropertyDisposals": [{}]
+      |}
+     """.stripMargin
+  )
+
+  val missingFieldsError: MtdError = RuleIncorrectOrEmptyBodyError.copy(
+    paths = Some(
+      Seq(
+        "/multiplePropertyDisposals/0/ppdSubmissionId",
+        "/singlePropertyDisposals/0/acquisitionAmount",
+        "/singlePropertyDisposals/0/additionalCosts",
+        "/singlePropertyDisposals/0/completionDate",
+        "/singlePropertyDisposals/0/disposalProceeds",
+        "/singlePropertyDisposals/0/improvementCosts",
+        "/singlePropertyDisposals/0/otherReliefAmount",
+        "/singlePropertyDisposals/0/ppdSubmissionId",
+        "/singlePropertyDisposals/0/prfAmount"
+      ))
+  )
+
+  val gainAndLossJson: JsValue = Json.parse(
+    """
+      |{
+      |    "multiplePropertyDisposals": [
+      |         {
+      |            "ppdSubmissionId": "AB0000000092",
+      |            "amountOfNetGain": 1234.78,
+      |            "amountOfNetLoss": 134.99
+      |         }
+      |    ],
+      |    "singlePropertyDisposals": [
+      |         {
+      |             "ppdSubmissionId": "AB0000000098",
+      |             "completionDate": "2020-02-28",
+      |             "disposalProceeds": 454.24,
+      |             "acquisitionDate": "2020-03-29",
+      |             "acquisitionAmount": 3434.45,
+      |             "improvementCosts": 233.45,
+      |             "additionalCosts": 423.34,
+      |             "prfAmount": 2324.67,
+      |             "otherReliefAmount": 3434.23,
+      |             "lossesFromThisYear": 436.23,
+      |             "lossesFromPreviousYear": 234.23,
+      |             "amountOfNetGain": 4567.89,
+      |             "amountOfNetLoss": 50000.99
+      |         }
+      |    ]
+      |}
+      |""".stripMargin
+  )
+
+  val amountGainLossError: MtdError = RuleAmountGainLossError.copy(
+    paths = Some(
+      Seq(
+        "/multiplePropertyDisposals/0",
+        "/singlePropertyDisposals/0"
+      ))
+  )
+
+  val lossGreaterThanGainJson: JsValue = Json.parse(
+    """
+      |{
+      |    "multiplePropertyDisposals": [
+      |         {
+      |            "ppdSubmissionId": "AB0000000092",
+      |            "amountOfNetGain": 1234.78
+      |         }
+      |    ],
+      |    "singlePropertyDisposals": [
+      |         {
+      |             "ppdSubmissionId": "AB0000000098",
+      |             "completionDate": "2020-02-28",
+      |             "disposalProceeds": 454.24,
+      |             "acquisitionDate": "2020-03-29",
+      |             "acquisitionAmount": 3434.45,
+      |             "improvementCosts": 233.45,
+      |             "additionalCosts": 423.34,
+      |             "prfAmount": 2324.67,
+      |             "otherReliefAmount": 3434.23,
+      |             "lossesFromThisYear": 6464.99,
+      |             "lossesFromPreviousYear": 234.23,
+      |             "amountOfNetGain": 4567.89
+      |         }
+      |    ]
+      |}
+      |""".stripMargin
+  )
+
+  private val invalidValueRequestBodyJson: JsValue = Json.parse(
+    """
+      |{
+      |    "multiplePropertyDisposals": [
+      |         {
+      |            "ppdSubmissionId": "AB0000000092",
+      |            "amountOfNetGain": 1234.787385
+      |         },
+      |         {
+      |            "ppdSubmissionId": "AB0000000092",
+      |            "amountOfNetLoss": -134.99
+      |         }
+      |    ],
+      |    "singlePropertyDisposals": [
+      |         {
+      |             "ppdSubmissionId": "AB0000000092",
+      |             "completionDate": "2020-02-28",
+      |             "disposalProceeds": 454.24999,
+      |             "acquisitionDate": "2020-03-29",
+      |             "acquisitionAmount": 3434.45346,
+      |             "improvementCosts": 233.4628,
+      |             "additionalCosts": 423.34829,
+      |             "prfAmount": -2324.67,
+      |             "otherReliefAmount": -3434.23,
+      |             "lossesFromThisYear": 436.23297423,
+      |             "lossesFromPreviousYear": 234.2334728,
+      |             "amountOfNetGain": 4567.8974726
+      |         },
+      |         {
+      |             "ppdSubmissionId": "AB0000000092",
+      |             "completionDate": "2020-02-28",
+      |             "disposalProceeds": -454.24,
+      |             "acquisitionDate": "2020-03-29",
+      |             "acquisitionAmount": 3434.45837,
+      |             "improvementCosts": 233.4628,
+      |             "additionalCosts": -423.34,
+      |             "prfAmount": 2324.678372,
+      |             "otherReliefAmount": -3434.23,
+      |             "lossesFromThisYear": 436.23287,
+      |             "lossesFromPreviousYear": -234.23,
+      |             "amountOfNetLoss": 4567.8983724
+      |         }
+      |    ]
+      |}
+      |""".stripMargin
+  )
+
+  val invalidValueErrors: MtdError = ValueFormatError.copy(
+    message = "The value must be between 0 and 99999999999.99",
+    paths = Some(
+      Seq(
+        "/multiplePropertyDisposals/0/amountOfNetGain",
+        "/multiplePropertyDisposals/1/amountOfNetLoss",
+        "/singlePropertyDisposals/0/disposalProceeds",
+        "/singlePropertyDisposals/0/acquisitionAmount",
+        "/singlePropertyDisposals/0/improvementCosts",
+        "/singlePropertyDisposals/0/additionalCosts",
+        "/singlePropertyDisposals/0/prfAmount",
+        "/singlePropertyDisposals/0/otherReliefAmount",
+        "/singlePropertyDisposals/0/lossesFromThisYear",
+        "/singlePropertyDisposals/0/lossesFromPreviousYear",
+        "/singlePropertyDisposals/0/amountOfNetGain",
+        "/singlePropertyDisposals/1/disposalProceeds",
+        "/singlePropertyDisposals/1/acquisitionAmount",
+        "/singlePropertyDisposals/1/improvementCosts",
+        "/singlePropertyDisposals/1/additionalCosts",
+        "/singlePropertyDisposals/1/prfAmount",
+        "/singlePropertyDisposals/1/otherReliefAmount",
+        "/singlePropertyDisposals/1/lossesFromThisYear",
+        "/singlePropertyDisposals/1/lossesFromPreviousYear",
+        "/singlePropertyDisposals/1/amountOfNetLoss"
+      ))
+  )
+
+  def jsonWithIds(multipleSubmissionId: String, singleSubmissionId: String): JsValue = Json.parse(
+    s"""
+       |{
+       |    "multiplePropertyDisposals": [
+       |         {
+       |            "ppdSubmissionId": "$multipleSubmissionId",
+       |            "amountOfNetGain": 1234.78
+       |         }
+       |    ],
+       |    "singlePropertyDisposals": [
+       |         {
+       |             "ppdSubmissionId": "$singleSubmissionId",
+       |             "completionDate": "2020-02-28",
+       |             "disposalProceeds": 454.24,
+       |             "acquisitionDate": "2020-03-29",
+       |             "acquisitionAmount": 3434.45,
+       |             "improvementCosts": 233.45,
+       |             "additionalCosts": 423.34,
+       |             "prfAmount": 2324.67,
+       |             "otherReliefAmount": 3434.23,
+       |             "lossesFromThisYear": 436.23,
+       |             "lossesFromPreviousYear": 234.23,
+       |             "amountOfNetGain": 4567.89
+       |         }
+       |    ]
+       |}
+       |""".stripMargin
+  )
+
+  val ppdSubmissionFormatError: MtdError = PpdSubmissionIdFormatError.copy(
+    paths = Some(
+      Seq(
+        "/multiplePropertyDisposals/0/ppdSubmissionId",
+        "/singlePropertyDisposals/0/ppdSubmissionId"
+      ))
+  )
+
+  val invalidDateFormatJson: JsValue = Json.parse(
+    """
+      |{
+      |    "multiplePropertyDisposals": [
+      |         {
+      |            "ppdSubmissionId": "AB0000000091",
+      |            "amountOfNetGain": 1234.78
+      |         }
+      |    ],
+      |    "singlePropertyDisposals": [
+      |         {
+      |             "ppdSubmissionId": "AB0000000092",
+      |             "completionDate": "20-02-28",
+      |             "disposalProceeds": 454.24,
+      |             "acquisitionDate": "2003-29",
+      |             "acquisitionAmount": 3434.45,
+      |             "improvementCosts": 233.45,
+      |             "additionalCosts": 423.34,
+      |             "prfAmount": 2324.67,
+      |             "otherReliefAmount": 3434.23,
+      |             "lossesFromThisYear": 436.23,
+      |             "lossesFromPreviousYear": 234.23,
+      |             "amountOfNetGain": 4567.89
+      |         }
+      |    ]
+      |}
+      |""".stripMargin
+  )
+
+  val dateFormatError: MtdError = DateFormatError.copy(
+    paths = Some(
+      Seq(
+        "/singlePropertyDisposals/0/completionDate",
+        "/singlePropertyDisposals/0/acquisitionDate"
+      ))
+  )
+
+  private trait Test {
+
+    def nino: String = "AA123456A"
+    def taxYear: String
+    def downstreamUri: String
+    def uri: String = s"/residential-property/$nino/$taxYear/ppd"
+
+    def setupStubs(): StubMapping
+
+    def request: WSRequest = {
+      setupStubs()
+      buildRequest(uri)
+        .withHttpHeaders(
+          (ACCEPT, "application/vnd.hmrc.2.0+json"),
+          (AUTHORIZATION, "Bearer 123") // some bearer token
+        )
+    }
+
+    def verifyNrs(payload: JsValue): Unit =
+      verify(
+        postRequestedFor(urlEqualTo(s"/mtd-api-nrs-proxy/$nino/itsa-cgt-disposal-ppd"))
+          .withRequestBody(equalToJson(payload.toString())))
+
+  }
+
+  private trait NonTysTest extends Test {
+    def taxYear               = "2020-21"
+    def downstreamUri: String = s"/income-tax/income/disposals/residential-property/ppd/$nino/$taxYear"
+  }
+
+  private trait TysIfsTest extends Test {
+    def taxYear               = "2023-24"
+    def downstreamUri: String = s"/income-tax/income/disposals/residential-property/ppd/23-24/$nino"
+
+    override def request: WSRequest =
+      super.request.addHttpHeaders("suspend-temporal-validations" -> "true")
+
+  }
+
+  "Calling Create and Amend 'Report and Pay Capital Gains Tax on Property' Overrides endpoint" should {
+    "return a 200 status code" when {
+      "any valid request is made" in new NonTysTest {
+
+        override def setupStubs(): StubMapping = {
+          AuthStub.authorised()
+          MtdIdLookupStub.ninoFound(nino)
+          DownstreamStub.onSuccess(DownstreamStub.PUT, downstreamUri, NO_CONTENT)
+        }
+
+        val response: WSResponse = await(request.put(validRequestBodyJson))
+        response.status shouldBe OK
+
+        verifyNrs(validRequestBodyJson)
+      }
+
+      "any valid request is made for a TYS tax year" in new TysIfsTest {
+
+        override def setupStubs(): StubMapping = {
+          AuthStub.authorised()
+          MtdIdLookupStub.ninoFound(nino)
+          DownstreamStub.onSuccess(DownstreamStub.PUT, downstreamUri, NO_CONTENT)
+        }
+
+        val response: WSResponse = await(request.put(validRequestBodyJson))
+        response.status shouldBe OK
+
+        verifyNrs(validRequestBodyJson)
+      }
+    }
+
+    "return a 400 with multiple errors" when {
+      "validation error" when {
+        def validationErrorTest(requestNino: String,
+                                requestTaxYear: String,
+                                requestBody: JsValue,
+                                expectedStatus: Int,
+                                expectedError: MtdError,
+                                expectedErrors: Option[ErrorWrapper],
+                                scenario: Option[String]): Unit = {
+          s"validation fails with ${expectedError.code} error${scenario.fold("")(scenario => s" for $scenario scenario")}" in new NonTysTest {
+            override val nino: String    = requestNino
+            override val taxYear: String = requestTaxYear
+
+            override def setupStubs(): StubMapping = {
+              AuditStub.audit()
+              AuthStub.authorised()
+              MtdIdLookupStub.ninoFound(nino)
+            }
+
+            val response: WSResponse = await(request.put(requestBody))
+            response.status shouldBe expectedStatus
+            response.json shouldBe expectedErrors.fold(Json.toJson(expectedError))(errorWrapper => Json.toJson(errorWrapper))
+            response.header("Content-Type") shouldBe Some("application/json")
+          }
+
+          s"validation fails with ${expectedError.code} error${scenario.fold("")(scenario => s" for $scenario scenario")} for TYS tax year" in new TysIfsTest {
+            override val nino: String    = requestNino
+            override val taxYear: String = requestTaxYear
+
+            override def setupStubs(): StubMapping = {
+              AuditStub.audit()
+              AuthStub.authorised()
+              MtdIdLookupStub.ninoFound(nino)
+            }
+
+            val response: WSResponse = await(request.put(requestBody))
+            response.status shouldBe expectedStatus
+            response.json shouldBe expectedErrors.fold(Json.toJson(expectedError))(errorWrapper => Json.toJson(errorWrapper))
+            response.header("Content-Type") shouldBe Some("application/json")
+          }
+        }
+
+        val input = Seq(
+          // Path errors
+          ("AA1123A", "2020-21", validRequestBodyJson, BAD_REQUEST, NinoFormatError, None, None),
+          ("AA123456A", "20177", validRequestBodyJson, BAD_REQUEST, TaxYearFormatError, None, None),
+          ("AA123456A", "2015-17", validRequestBodyJson, BAD_REQUEST, RuleTaxYearRangeInvalidError, None, None),
+          ("AA123456A", "2018-19", validRequestBodyJson, BAD_REQUEST, RuleTaxYearNotSupportedError, None, None),
+          ("AA123456A", "2025-26", validRequestBodyJson, BAD_REQUEST, RuleTaxYearForVersionNotSupportedError, None, None),
+
+          // Body Errors
+          ("AA123456A", "2020-21", JsObject.empty, BAD_REQUEST, RuleIncorrectOrEmptyBodyError, None, Some("emptyBody")),
+          ("AA123456A", "2020-21", nonsenseBodyJson, BAD_REQUEST, RuleIncorrectOrEmptyBodyError, None, Some("nonsenseBody")),
+          ("AA123456A", "2020-21", emptyFieldsJson, BAD_REQUEST, emptyFieldsError, None, Some("emptyFields")),
+          ("AA123456A", "2020-21", missingFieldsJson, BAD_REQUEST, missingFieldsError, None, Some("missingFields")),
+          ("AA123456A", "2020-21", gainAndLossJson, BAD_REQUEST, amountGainLossError, None, Some("gainAndLossRule")),
+          ("AA123456A", "2020-21", invalidDateFormatJson, BAD_REQUEST, dateFormatError, None, Some("dateFormat")),
+          ("AA123456A", "2020-21", invalidValueRequestBodyJson, BAD_REQUEST, invalidValueErrors, None, Some("invalidNumValues")),
+          ("AA123456A", "2020-21", jsonWithIds("notAnID", "notAnID"), BAD_REQUEST, ppdSubmissionFormatError, None, Some("badIDs"))
+        )
+        input.foreach(args => (validationErrorTest).tupled(args))
+      }
+
+      "ifs service error" when {
+        def serviceErrorTest(ifsStatus: Int, ifsCode: String, expectedStatus: Int, expectedBody: MtdError): Unit = {
+          s"ifs returns an $ifsCode error and status $ifsStatus" in new NonTysTest {
+
+            override def setupStubs(): StubMapping = {
+              AuditStub.audit()
+              AuthStub.authorised()
+              MtdIdLookupStub.ninoFound(nino)
+              DownstreamStub.onError(DownstreamStub.PUT, downstreamUri, ifsStatus, errorBody(ifsCode))
+            }
+
+            val response: WSResponse = await(request.put(validRequestBodyJson))
+            response.status shouldBe expectedStatus
+            response.json shouldBe Json.toJson(expectedBody)
+            response.header("Content-Type") shouldBe Some("application/json")
+
+            verifyNrs(validRequestBodyJson)
+          }
+
+        }
+
+        def errorBody(code: String): String =
+          s"""
+             |{
+             |   "code": "$code",
+             |   "reason": "ifs message"
+             |}
+            """.stripMargin
+
+        val errors = Seq(
+          (BAD_REQUEST, "INVALID_TAXABLE_ENTITY_ID", BAD_REQUEST, NinoFormatError),
+          (BAD_REQUEST, "INVALID_TAX_YEAR", BAD_REQUEST, TaxYearFormatError),
+          (BAD_REQUEST, "INVALID_CORRELATIONID", INTERNAL_SERVER_ERROR, InternalError),
+          (BAD_REQUEST, "INVALID_PAYLOAD", INTERNAL_SERVER_ERROR, InternalError),
+          (NOT_FOUND, "PPD_SUBMISSIONID_NOT_FOUND", NOT_FOUND, PpdSubmissionIdNotFoundError),
+          (NOT_FOUND, "NO_PPD_SUBMISSIONS_FOUND", NOT_FOUND, NotFoundError),
+          (CONFLICT, "DUPLICATE_SUBMISSION", BAD_REQUEST, RuleDuplicatedPpdSubmissionIdError),
+          (UNPROCESSABLE_ENTITY, "INVALID_DISPOSAL_TYPE", BAD_REQUEST, RuleIncorrectDisposalTypeError),
+          (UNPROCESSABLE_ENTITY, "OUTSIDE_AMENDMENT_WINDOW", BAD_REQUEST, RuleOutsideAmendmentWindowError),
+          (INTERNAL_SERVER_ERROR, "SERVER_ERROR", INTERNAL_SERVER_ERROR, InternalError),
+          (SERVICE_UNAVAILABLE, "SERVICE_UNAVAILABLE", INTERNAL_SERVER_ERROR, InternalError)
+        )
+
+        val extraTysErrors = Seq(
+          (BAD_REQUEST, "TAX_YEAR_NOT_SUPPORTED", BAD_REQUEST, RuleTaxYearNotSupportedError)
+        )
+
+        (errors ++ extraTysErrors).foreach(args => (serviceErrorTest).tupled(args))
+      }
+    }
+  }
+
+}

--- a/it/test/v2/endpoints/CreateAmendCgtResidentialPropertyDisposalsControllerHipISpec.scala
+++ b/it/test/v2/endpoints/CreateAmendCgtResidentialPropertyDisposalsControllerHipISpec.scala
@@ -1,0 +1,428 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v2.endpoints
+
+import com.github.tomakehurst.wiremock.client.WireMock.*
+import com.github.tomakehurst.wiremock.stubbing.StubMapping
+import common.errors.*
+import play.api.http.HeaderNames.ACCEPT
+import play.api.http.Status.*
+import play.api.libs.json.{JsObject, JsValue, Json}
+import play.api.libs.ws.WSBodyWritables.writeableOf_JsValue
+import play.api.libs.ws.{WSRequest, WSResponse}
+import play.api.test.Helpers.AUTHORIZATION
+import shared.models.errors.*
+import shared.services.*
+import shared.support.{IntegrationBaseSpec, WireMockMethods}
+
+class CreateAmendCgtResidentialPropertyDisposalsControllerHipISpec extends IntegrationBaseSpec with WireMockMethods {
+
+  val validDisposalDate: String    = "2020-03-27"
+  val validCompletionDate: String  = "2020-03-29"
+  val validAcquisitionDate: String = "2020-03-25"
+
+  val validRequestJson: JsValue = Json.parse(
+    s"""
+      |{
+      |   "disposals":[
+      |      {
+      |         "customerReference": "CGTDISPOSAL01",
+      |         "disposalDate": "$validDisposalDate",
+      |         "completionDate": "$validCompletionDate",
+      |         "disposalProceeds": 1999.99,
+      |         "acquisitionDate": "$validAcquisitionDate",
+      |         "acquisitionAmount": 1999.99,
+      |         "improvementCosts": 1999.99,
+      |         "additionalCosts": 1999.99,
+      |         "prfAmount": 1999.99,
+      |         "otherReliefAmount": 1999.99,
+      |         "lossesFromThisYear": 1999.99,
+      |         "lossesFromPreviousYear": 1999.99,
+      |         "amountOfNetGain": 1999.99
+      |      }
+      |   ]
+      |}
+     """.stripMargin
+  )
+
+  val noMeaningfulDataJson: JsValue = Json.parse(
+    """
+      |{
+      |  "aField": "aValue"
+      |}
+       """.stripMargin
+  )
+
+  val emptyDisposalsJson: JsValue = Json.parse(
+    """
+      |{
+      |   "disposals": []
+      |}
+     """.stripMargin
+  )
+
+  val emptyDisposalsError: MtdError = RuleIncorrectOrEmptyBodyError.copy(
+    paths = Some(Seq("/disposals"))
+  )
+
+  val missingFieldsJson: JsValue = Json.parse(
+    """
+      |{
+      |   "disposals": [{}]
+      |}
+     """.stripMargin
+  )
+
+  val missingFieldsError: MtdError = RuleIncorrectOrEmptyBodyError.copy(
+    paths = Some(
+      Seq(
+        "/disposals/0/acquisitionAmount",
+        "/disposals/0/acquisitionDate",
+        "/disposals/0/completionDate",
+        "/disposals/0/disposalDate",
+        "/disposals/0/disposalProceeds"
+      ))
+  )
+
+  val decimalsTooBigJson: JsValue = Json.parse(
+    s"""
+      |{
+      |   "disposals":[
+      |      {
+      |         "customerReference": "CGTDISPOSAL01",
+      |         "disposalDate": "$validDisposalDate",
+      |         "completionDate": "$validCompletionDate",
+      |         "disposalProceeds": 100000000000.00,
+      |         "acquisitionDate": "$validAcquisitionDate",
+      |         "acquisitionAmount": 100000000000.00,
+      |         "improvementCosts": 100000000000.00,
+      |         "additionalCosts": 100000000000.00,
+      |         "prfAmount": 100000000000.00,
+      |         "otherReliefAmount": 100000000000.00,
+      |         "lossesFromThisYear": 100000000000.00,
+      |         "lossesFromPreviousYear": 100000000000.00,
+      |         "amountOfNetGain": 100000000000.00
+      |      }
+      |   ]
+      |}
+     """.stripMargin
+  )
+
+  val decimalsTooSmallJson: JsValue = Json.parse(
+    s"""
+      |{
+      |   "disposals":[
+      |      {
+      |         "customerReference": "CGTDISPOSAL01",
+      |         "disposalDate": "$validDisposalDate",
+      |         "completionDate": "$validCompletionDate",
+      |         "disposalProceeds": -0.1,
+      |         "acquisitionDate": "$validAcquisitionDate",
+      |         "acquisitionAmount": -0.1,
+      |         "improvementCosts": -0.1,
+      |         "additionalCosts": -0.1,
+      |         "prfAmount": -0.1,
+      |         "otherReliefAmount": -0.1,
+      |         "lossesFromThisYear": -0.1,
+      |         "lossesFromPreviousYear": -0.1,
+      |         "amountOfNetGain": -0.1
+      |      }
+      |   ]
+      |}
+     """.stripMargin
+  )
+
+  val DecimalsOutOfRangeError: MtdError = ValueFormatError.copy(
+    message = "The value must be between 0 and 99999999999.99",
+    paths = Some(
+      Seq(
+        "/disposals/0/disposalProceeds",
+        "/disposals/0/acquisitionAmount",
+        "/disposals/0/improvementCosts",
+        "/disposals/0/additionalCosts",
+        "/disposals/0/prfAmount",
+        "/disposals/0/otherReliefAmount",
+        "/disposals/0/lossesFromThisYear",
+        "/disposals/0/lossesFromPreviousYear",
+        "/disposals/0/amountOfNetGain"
+      ))
+  )
+
+  val datesNotFormattedJson: JsValue = Json.parse(
+    s"""
+      |{
+      |   "disposals":[
+      |      {
+      |         "customerReference": "CGTDISPOSAL01",
+      |         "disposalDate": "202005-07",
+      |         "completionDate": "21-05-07",
+      |         "disposalProceeds": 1999.99,
+      |         "acquisitionDate": "2020-5-7",
+      |         "acquisitionAmount": 1999.99,
+      |         "improvementCosts": 1999.99,
+      |         "additionalCosts": 1999.99,
+      |         "prfAmount": 1999.99,
+      |         "otherReliefAmount": 1999.99,
+      |         "lossesFromThisYear": 1999.99,
+      |         "lossesFromPreviousYear": 1999.99,
+      |         "amountOfNetGain": 1999.99
+      |      }
+      |   ]
+      |}
+     """.stripMargin
+  )
+
+  val datesNotFormattedError: MtdError = DateFormatError.copy(
+    message = "The supplied date format is not valid",
+    paths = Some(
+      Seq(
+        "/disposals/0/disposalDate",
+        "/disposals/0/completionDate",
+        "/disposals/0/acquisitionDate"
+      ))
+  )
+
+  val customerRefTooLongJson: JsValue = Json.parse(
+    s"""
+      |{
+      |   "disposals":[
+      |      {
+      |         "customerReference": "ThisIs91CharactersLongCGTDIS000000000000000000000000000000000000000000000000000000000000001",
+      |         "disposalDate": "$validDisposalDate",
+      |         "completionDate": "$validCompletionDate",
+      |         "disposalProceeds": 1999.99,
+      |         "acquisitionDate": "$validAcquisitionDate",
+      |         "acquisitionAmount": 1999.99,
+      |         "improvementCosts": 1999.99,
+      |         "additionalCosts": 1999.99,
+      |         "prfAmount": 1999.99,
+      |         "otherReliefAmount": 1999.99,
+      |         "lossesFromThisYear": 1999.99,
+      |         "lossesFromPreviousYear": 1999.99,
+      |         "amountOfNetGain": 1999.99
+      |      }
+      |   ]
+      |}
+     """.stripMargin
+  )
+
+  val customerRefTooShortJson: JsValue = Json.parse(
+    s"""
+      |{
+      |   "disposals":[
+      |      {
+      |         "customerReference": "",
+      |         "disposalDate": "$validDisposalDate",
+      |         "completionDate": "$validCompletionDate",
+      |         "disposalProceeds": 1999.99,
+      |         "acquisitionDate": "$validAcquisitionDate",
+      |         "acquisitionAmount": 1999.99,
+      |         "improvementCosts": 1999.99,
+      |         "additionalCosts": 1999.99,
+      |         "prfAmount": 1999.99,
+      |         "otherReliefAmount": 1999.99,
+      |         "lossesFromThisYear": 1999.99,
+      |         "lossesFromPreviousYear": 1999.99,
+      |         "amountOfNetGain": 1999.99
+      |      }
+      |   ]
+      |}
+     """.stripMargin
+  )
+
+  val customerRefError: MtdError = CustomerRefFormatError.withPath("/disposals/0/customerReference")
+
+  val gainLossJson: JsValue = Json.parse(
+    s"""
+      |{
+      |   "disposals":[
+      |      {
+      |         "customerReference": "CGTDISPOSAL01",
+      |         "disposalDate": "$validDisposalDate",
+      |         "completionDate": "$validCompletionDate",
+      |         "disposalProceeds": 1999.99,
+      |         "acquisitionDate": "$validAcquisitionDate",
+      |         "acquisitionAmount": 1999.99,
+      |         "improvementCosts": 1999.99,
+      |         "additionalCosts": 1999.99,
+      |         "prfAmount": 1999.99,
+      |         "otherReliefAmount": 1999.99,
+      |         "lossesFromThisYear": 1999.99,
+      |         "lossesFromPreviousYear": 1999.99,
+      |         "amountOfNetGain": 19999.99,
+      |         "amountOfNetLoss": 19999.99
+      |      }
+      |   ]
+      |}
+     """.stripMargin
+  )
+
+  val gainLossError: MtdError = RuleGainLossError.copy(
+    message = "Only one of gain or loss values can be provided",
+    paths = Some(
+      Seq(
+        "/disposals/0"
+      ))
+  )
+
+  trait Test {
+
+    val nino: String    = "AA123456A"
+    def taxYear: String = "2023-24"
+
+    def downstreamUri: String = s"/itsa/income-tax/v1/23-24/income/disposals/residential-property/$nino"
+
+    def setupStubs(): StubMapping
+
+    def request: WSRequest = {
+      setupStubs()
+      buildRequest(s"/residential-property/$nino/$taxYear")
+        .withHttpHeaders(
+          (ACCEPT, "application/vnd.hmrc.2.0+json"),
+          (AUTHORIZATION, "Bearer 123") // some bearer token
+        )
+    }
+
+    def verifyNrs(payload: JsValue): Unit =
+      verify(
+        postRequestedFor(urlEqualTo(s"/mtd-api-nrs-proxy/$nino/itsa-cgt-disposal"))
+          .withRequestBody(equalToJson(payload.toString())))
+
+  }
+
+  "Calling the 'create and amend other CGT' endpoint" should {
+    "return a 200 status code" when {
+      "any valid request is made for a TYS tax year" in new Test {
+
+        override def setupStubs(): StubMapping = {
+          AuditStub.audit()
+          AuthStub.authorised()
+          MtdIdLookupStub.ninoFound(nino)
+          DownstreamStub.onSuccess(DownstreamStub.PUT, downstreamUri, NO_CONTENT)
+        }
+
+        val response: WSResponse = await(request.put(validRequestJson))
+        response.status shouldBe OK
+
+        verifyNrs(validRequestJson)
+      }
+    }
+
+    "return error according to spec" when {
+      "validation error" when {
+        def validationErrorTest(requestNino: String,
+                                requestTaxYear: String,
+                                requestBody: JsValue,
+                                expectedStatus: Int,
+                                expectedError: MtdError,
+                                expectedErrors: Option[ErrorWrapper],
+                                scenario: Option[String]): Unit = {
+          s"validation fails with ${expectedError.code} error${scenario.fold("")(scenario => s" for $scenario scenario")}" in new Test {
+
+            override val nino: String    = requestNino
+            override val taxYear: String = requestTaxYear
+
+            override def setupStubs(): StubMapping = {
+              AuditStub.audit()
+              AuthStub.authorised()
+              MtdIdLookupStub.ninoFound(nino)
+            }
+
+            val response: WSResponse = await(request.put(requestBody))
+            response.status shouldBe expectedStatus
+            response.json shouldBe expectedErrors.fold(Json.toJson(expectedError))(errorWrapper => Json.toJson(errorWrapper))
+            response.header("Content-Type") shouldBe Some("application/json")
+          }
+        }
+
+        val input = Seq(
+          // Path errors
+          ("AA1123A", "2019-20", validRequestJson, BAD_REQUEST, NinoFormatError, None, None),
+          ("AA123456A", "20177", validRequestJson, BAD_REQUEST, TaxYearFormatError, None, None),
+          ("AA123456A", "2015-17", validRequestJson, BAD_REQUEST, RuleTaxYearRangeInvalidError, None, None),
+          ("AA123456A", "2018-19", validRequestJson, BAD_REQUEST, RuleTaxYearNotSupportedError, None, None),
+          ("AA123456A", "2025-26", validRequestJson, BAD_REQUEST, RuleTaxYearForVersionNotSupportedError, None, None),
+
+          // Body errors
+          ("AA123456A", "2019-20", JsObject.empty, BAD_REQUEST, RuleIncorrectOrEmptyBodyError, None, Some("emptyBody")),
+          ("AA123456A", "2019-20", emptyDisposalsJson, BAD_REQUEST, emptyDisposalsError, None, Some("empty disposals")),
+          ("AA123456A", "2019-20", missingFieldsJson, BAD_REQUEST, missingFieldsError, None, Some("missing all mandatory fields")),
+          ("AA123456A", "2019-20", decimalsTooBigJson, BAD_REQUEST, DecimalsOutOfRangeError, None, Some("Decimals too big")),
+          ("AA123456A", "2019-20", decimalsTooSmallJson, BAD_REQUEST, DecimalsOutOfRangeError, None, Some("Decimals too small")),
+          ("AA123456A", "2019-20", datesNotFormattedJson, BAD_REQUEST, datesNotFormattedError, None, Some("incorrect date formats")),
+          ("AA123456A", "2019-20", customerRefTooLongJson, BAD_REQUEST, customerRefError, None, Some("bad customer reference")),
+          ("AA123456A", "2019-20", customerRefTooShortJson, BAD_REQUEST, customerRefError, None, Some("empty customer reference string")),
+          ("AA123456A", "2019-20", gainLossJson, BAD_REQUEST, gainLossError, None, Some("gain and loss provided"))
+        )
+        input.foreach(args => validationErrorTest.tupled(args))
+      }
+
+      "service error" when {
+        def serviceErrorTest(downstreamStatus: Int, downstreamCode: String, expectedStatus: Int, expectedBody: MtdError): Unit = {
+          s"downstream returns an $downstreamCode error and status $downstreamStatus" in new Test {
+
+            override def setupStubs(): StubMapping = {
+              AuditStub.audit()
+              AuthStub.authorised()
+              MtdIdLookupStub.ninoFound(nino)
+              DownstreamStub.onError(DownstreamStub.PUT, downstreamUri, downstreamStatus, errorBody(downstreamCode))
+            }
+
+            val response: WSResponse = await(request.put(validRequestJson))
+            response.status shouldBe expectedStatus
+            response.json shouldBe Json.toJson(expectedBody)
+            response.header("Content-Type") shouldBe Some("application/json")
+
+            verifyNrs(validRequestJson)
+          }
+        }
+
+        def errorBody(`type`: String): String =
+          s"""
+             |{
+             |  "origin": "HIP",
+             |  "response": {
+             |    "failures": [
+             |      {
+             |        "type": "${`type`}",
+             |        "reason": "downstream message"
+             |      }
+             |    ]
+             |  }
+             |}
+             |""".stripMargin
+
+        val errors = Seq(
+          (BAD_REQUEST, "INVALID_TAXABLE_ENTITY_ID", BAD_REQUEST, NinoFormatError),
+          (BAD_REQUEST, "INVALID_TAX_YEAR", BAD_REQUEST, TaxYearFormatError),
+          (BAD_REQUEST, "INVALID_PAYLOAD", INTERNAL_SERVER_ERROR, InternalError),
+          (UNPROCESSABLE_ENTITY, "INVALID_DISPOSAL_DATE", BAD_REQUEST, RuleDisposalDateErrorV1),
+          (UNPROCESSABLE_ENTITY, "INVALID_COMPLETION_DATE", BAD_REQUEST, RuleCompletionDateError),
+          (UNPROCESSABLE_ENTITY, "INVALID_ACQUISITION_DATE", BAD_REQUEST, RuleAcquisitionDateAfterDisposalDateError),
+          (UNPROCESSABLE_ENTITY, "OUTSIDE_AMENDMENT_WINDOW", BAD_REQUEST, RuleOutsideAmendmentWindowError),
+          (INTERNAL_SERVER_ERROR, "SERVER_ERROR", INTERNAL_SERVER_ERROR, InternalError),
+          (SERVICE_UNAVAILABLE, "SERVICE_UNAVAILABLE", INTERNAL_SERVER_ERROR, InternalError),
+          (UNPROCESSABLE_ENTITY, "TAX_YEAR_NOT_SUPPORTED", BAD_REQUEST, RuleTaxYearNotSupportedError),
+          (BAD_REQUEST, "INVALID_CORRELATION_ID", INTERNAL_SERVER_ERROR, InternalError)
+        )
+
+        errors.foreach(args => serviceErrorTest.tupled(args))
+      }
+    }
+  }
+
+}

--- a/it/test/v2/endpoints/CreateAmendCgtResidentialPropertyDisposalsControllerIfsISpec.scala
+++ b/it/test/v2/endpoints/CreateAmendCgtResidentialPropertyDisposalsControllerIfsISpec.scala
@@ -1,0 +1,457 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v2.endpoints
+
+import com.github.tomakehurst.wiremock.client.WireMock.*
+import com.github.tomakehurst.wiremock.stubbing.StubMapping
+import common.errors.*
+import play.api.http.HeaderNames.ACCEPT
+import play.api.http.Status.*
+import play.api.libs.json.{JsObject, JsValue, Json}
+import play.api.libs.ws.WSBodyWritables.writeableOf_JsValue
+import play.api.libs.ws.{WSRequest, WSResponse}
+import play.api.test.Helpers.AUTHORIZATION
+import shared.models.errors.*
+import shared.services.*
+import shared.support.{IntegrationBaseSpec, WireMockMethods}
+
+class CreateAmendCgtResidentialPropertyDisposalsControllerIfsISpec extends IntegrationBaseSpec with WireMockMethods {
+
+  override def servicesConfig: Map[String, Any] =
+    Map("feature-switch.ifs_hip_migration_1952.enabled" -> false) ++ super.servicesConfig
+
+  val validDisposalDate: String    = "2020-03-27"
+  val validCompletionDate: String  = "2020-03-29"
+  val validAcquisitionDate: String = "2020-03-25"
+
+  val validRequestJson: JsValue = Json.parse(
+    s"""
+      |{
+      |   "disposals":[
+      |      {
+      |         "customerReference": "CGTDISPOSAL01",
+      |         "disposalDate": "$validDisposalDate",
+      |         "completionDate": "$validCompletionDate",
+      |         "disposalProceeds": 1999.99,
+      |         "acquisitionDate": "$validAcquisitionDate",
+      |         "acquisitionAmount": 1999.99,
+      |         "improvementCosts": 1999.99,
+      |         "additionalCosts": 1999.99,
+      |         "prfAmount": 1999.99,
+      |         "otherReliefAmount": 1999.99,
+      |         "lossesFromThisYear": 1999.99,
+      |         "lossesFromPreviousYear": 1999.99,
+      |         "amountOfNetGain": 1999.99
+      |      }
+      |   ]
+      |}
+     """.stripMargin
+  )
+
+  val noMeaningfulDataJson: JsValue = Json.parse(
+    """
+      |{
+      |  "aField": "aValue"
+      |}
+       """.stripMargin
+  )
+
+  val emptyDisposalsJson: JsValue = Json.parse(
+    """
+      |{
+      |   "disposals": []
+      |}
+     """.stripMargin
+  )
+
+  val emptyDisposalsError: MtdError = RuleIncorrectOrEmptyBodyError.copy(
+    paths = Some(Seq("/disposals"))
+  )
+
+  val missingFieldsJson: JsValue = Json.parse(
+    """
+      |{
+      |   "disposals": [{}]
+      |}
+     """.stripMargin
+  )
+
+  val missingFieldsError: MtdError = RuleIncorrectOrEmptyBodyError.copy(
+    paths = Some(
+      Seq(
+        "/disposals/0/acquisitionAmount",
+        "/disposals/0/acquisitionDate",
+        "/disposals/0/completionDate",
+        "/disposals/0/disposalDate",
+        "/disposals/0/disposalProceeds"
+      ))
+  )
+
+  val decimalsTooBigJson: JsValue = Json.parse(
+    s"""
+      |{
+      |   "disposals":[
+      |      {
+      |         "customerReference": "CGTDISPOSAL01",
+      |         "disposalDate": "$validDisposalDate",
+      |         "completionDate": "$validCompletionDate",
+      |         "disposalProceeds": 100000000000.00,
+      |         "acquisitionDate": "$validAcquisitionDate",
+      |         "acquisitionAmount": 100000000000.00,
+      |         "improvementCosts": 100000000000.00,
+      |         "additionalCosts": 100000000000.00,
+      |         "prfAmount": 100000000000.00,
+      |         "otherReliefAmount": 100000000000.00,
+      |         "lossesFromThisYear": 100000000000.00,
+      |         "lossesFromPreviousYear": 100000000000.00,
+      |         "amountOfNetGain": 100000000000.00
+      |      }
+      |   ]
+      |}
+     """.stripMargin
+  )
+
+  val decimalsTooSmallJson: JsValue = Json.parse(
+    s"""
+      |{
+      |   "disposals":[
+      |      {
+      |         "customerReference": "CGTDISPOSAL01",
+      |         "disposalDate": "$validDisposalDate",
+      |         "completionDate": "$validCompletionDate",
+      |         "disposalProceeds": -0.1,
+      |         "acquisitionDate": "$validAcquisitionDate",
+      |         "acquisitionAmount": -0.1,
+      |         "improvementCosts": -0.1,
+      |         "additionalCosts": -0.1,
+      |         "prfAmount": -0.1,
+      |         "otherReliefAmount": -0.1,
+      |         "lossesFromThisYear": -0.1,
+      |         "lossesFromPreviousYear": -0.1,
+      |         "amountOfNetGain": -0.1
+      |      }
+      |   ]
+      |}
+     """.stripMargin
+  )
+
+  val DecimalsOutOfRangeError: MtdError = ValueFormatError.copy(
+    message = "The value must be between 0 and 99999999999.99",
+    paths = Some(
+      Seq(
+        "/disposals/0/disposalProceeds",
+        "/disposals/0/acquisitionAmount",
+        "/disposals/0/improvementCosts",
+        "/disposals/0/additionalCosts",
+        "/disposals/0/prfAmount",
+        "/disposals/0/otherReliefAmount",
+        "/disposals/0/lossesFromThisYear",
+        "/disposals/0/lossesFromPreviousYear",
+        "/disposals/0/amountOfNetGain"
+      ))
+  )
+
+  val datesNotFormattedJson: JsValue = Json.parse(
+    s"""
+      |{
+      |   "disposals":[
+      |      {
+      |         "customerReference": "CGTDISPOSAL01",
+      |         "disposalDate": "202005-07",
+      |         "completionDate": "21-05-07",
+      |         "disposalProceeds": 1999.99,
+      |         "acquisitionDate": "2020-5-7",
+      |         "acquisitionAmount": 1999.99,
+      |         "improvementCosts": 1999.99,
+      |         "additionalCosts": 1999.99,
+      |         "prfAmount": 1999.99,
+      |         "otherReliefAmount": 1999.99,
+      |         "lossesFromThisYear": 1999.99,
+      |         "lossesFromPreviousYear": 1999.99,
+      |         "amountOfNetGain": 1999.99
+      |      }
+      |   ]
+      |}
+     """.stripMargin
+  )
+
+  val datesNotFormattedError: MtdError = DateFormatError.copy(
+    message = "The supplied date format is not valid",
+    paths = Some(
+      Seq(
+        "/disposals/0/disposalDate",
+        "/disposals/0/completionDate",
+        "/disposals/0/acquisitionDate"
+      ))
+  )
+
+  val customerRefTooLongJson: JsValue = Json.parse(
+    s"""
+      |{
+      |   "disposals":[
+      |      {
+      |         "customerReference": "ThisIs91CharactersLongCGTDIS000000000000000000000000000000000000000000000000000000000000001",
+      |         "disposalDate": "$validDisposalDate",
+      |         "completionDate": "$validCompletionDate",
+      |         "disposalProceeds": 1999.99,
+      |         "acquisitionDate": "$validAcquisitionDate",
+      |         "acquisitionAmount": 1999.99,
+      |         "improvementCosts": 1999.99,
+      |         "additionalCosts": 1999.99,
+      |         "prfAmount": 1999.99,
+      |         "otherReliefAmount": 1999.99,
+      |         "lossesFromThisYear": 1999.99,
+      |         "lossesFromPreviousYear": 1999.99,
+      |         "amountOfNetGain": 1999.99
+      |      }
+      |   ]
+      |}
+     """.stripMargin
+  )
+
+  val customerRefTooShortJson: JsValue = Json.parse(
+    s"""
+      |{
+      |   "disposals":[
+      |      {
+      |         "customerReference": "",
+      |         "disposalDate": "$validDisposalDate",
+      |         "completionDate": "$validCompletionDate",
+      |         "disposalProceeds": 1999.99,
+      |         "acquisitionDate": "$validAcquisitionDate",
+      |         "acquisitionAmount": 1999.99,
+      |         "improvementCosts": 1999.99,
+      |         "additionalCosts": 1999.99,
+      |         "prfAmount": 1999.99,
+      |         "otherReliefAmount": 1999.99,
+      |         "lossesFromThisYear": 1999.99,
+      |         "lossesFromPreviousYear": 1999.99,
+      |         "amountOfNetGain": 1999.99
+      |      }
+      |   ]
+      |}
+     """.stripMargin
+  )
+
+  val customerRefError: MtdError = CustomerRefFormatError.withPath("/disposals/0/customerReference")
+
+  val gainLossJson: JsValue = Json.parse(
+    s"""
+      |{
+      |   "disposals":[
+      |      {
+      |         "customerReference": "CGTDISPOSAL01",
+      |         "disposalDate": "$validDisposalDate",
+      |         "completionDate": "$validCompletionDate",
+      |         "disposalProceeds": 1999.99,
+      |         "acquisitionDate": "$validAcquisitionDate",
+      |         "acquisitionAmount": 1999.99,
+      |         "improvementCosts": 1999.99,
+      |         "additionalCosts": 1999.99,
+      |         "prfAmount": 1999.99,
+      |         "otherReliefAmount": 1999.99,
+      |         "lossesFromThisYear": 1999.99,
+      |         "lossesFromPreviousYear": 1999.99,
+      |         "amountOfNetGain": 19999.99,
+      |         "amountOfNetLoss": 19999.99
+      |      }
+      |   ]
+      |}
+     """.stripMargin
+  )
+
+  val gainLossError: MtdError = RuleGainLossError.copy(
+    message = "Only one of gain or loss values can be provided",
+    paths = Some(
+      Seq(
+        "/disposals/0"
+      ))
+  )
+
+  trait Test {
+
+    val nino: String = "AA123456A"
+    def taxYear: String
+
+    def downstreamUri: String
+
+    def setupStubs(): StubMapping
+
+    def request: WSRequest = {
+      setupStubs()
+      buildRequest(s"/residential-property/$nino/$taxYear")
+        .withHttpHeaders(
+          (ACCEPT, "application/vnd.hmrc.2.0+json"),
+          (AUTHORIZATION, "Bearer 123") // some bearer token
+        )
+    }
+
+    def verifyNrs(payload: JsValue): Unit =
+      verify(
+        postRequestedFor(urlEqualTo(s"/mtd-api-nrs-proxy/$nino/itsa-cgt-disposal"))
+          .withRequestBody(equalToJson(payload.toString())))
+
+  }
+
+  trait NonTysTest extends Test {
+    def taxYear: String = "2019-20"
+
+    def downstreamUri: String = s"/income-tax/income/disposals/residential-property/$nino/2019-20"
+  }
+
+  trait TysTest extends Test {
+    def taxYear: String = "2023-24"
+
+    override def request: WSRequest =
+      super.request.addHttpHeaders("suspend-temporal-validations" -> "true")
+
+    def downstreamUri: String = s"/income-tax/income/disposals/residential-property/23-24/$nino"
+  }
+
+  "Calling the 'create and amend other CGT' endpoint" should {
+    "return a 200 status code" when {
+      "any valid request is made" in new NonTysTest {
+
+        override def setupStubs(): StubMapping = {
+          AuditStub.audit()
+          AuthStub.authorised()
+          MtdIdLookupStub.ninoFound(nino)
+          DownstreamStub.onSuccess(DownstreamStub.PUT, downstreamUri, NO_CONTENT)
+        }
+
+        val response: WSResponse = await(request.put(validRequestJson))
+        response.status shouldBe OK
+
+        verifyNrs(validRequestJson)
+      }
+
+      "any valid request is made for a TYS tax year" in new TysTest {
+
+        override def setupStubs(): StubMapping = {
+          AuditStub.audit()
+          AuthStub.authorised()
+          MtdIdLookupStub.ninoFound(nino)
+          DownstreamStub.onSuccess(DownstreamStub.PUT, downstreamUri, NO_CONTENT)
+        }
+
+        val response: WSResponse = await(request.put(validRequestJson))
+        response.status shouldBe OK
+
+        verifyNrs(validRequestJson)
+      }
+    }
+
+    "return error according to spec" when {
+      "validation error" when {
+        def validationErrorTest(requestNino: String,
+                                requestTaxYear: String,
+                                requestBody: JsValue,
+                                expectedStatus: Int,
+                                expectedError: MtdError,
+                                expectedErrors: Option[ErrorWrapper],
+                                scenario: Option[String]): Unit = {
+          s"validation fails with ${expectedError.code} error${scenario.fold("")(scenario => s" for $scenario scenario")}" in new NonTysTest {
+
+            override val nino: String    = requestNino
+            override val taxYear: String = requestTaxYear
+
+            override def setupStubs(): StubMapping = {
+              AuditStub.audit()
+              AuthStub.authorised()
+              MtdIdLookupStub.ninoFound(nino)
+            }
+
+            val response: WSResponse = await(request.put(requestBody))
+            response.status shouldBe expectedStatus
+            response.json shouldBe expectedErrors.fold(Json.toJson(expectedError))(errorWrapper => Json.toJson(errorWrapper))
+            response.header("Content-Type") shouldBe Some("application/json")
+          }
+        }
+
+        val input = Seq(
+          // Path errors
+          ("AA1123A", "2019-20", validRequestJson, BAD_REQUEST, NinoFormatError, None, None),
+          ("AA123456A", "20177", validRequestJson, BAD_REQUEST, TaxYearFormatError, None, None),
+          ("AA123456A", "2015-17", validRequestJson, BAD_REQUEST, RuleTaxYearRangeInvalidError, None, None),
+          ("AA123456A", "2018-19", validRequestJson, BAD_REQUEST, RuleTaxYearNotSupportedError, None, None),
+          ("AA123456A", "2025-26", validRequestJson, BAD_REQUEST, RuleTaxYearForVersionNotSupportedError, None, None),
+          // Body errors
+          ("AA123456A", "2019-20", JsObject.empty, BAD_REQUEST, RuleIncorrectOrEmptyBodyError, None, Some("emptyBody")),
+          ("AA123456A", "2019-20", emptyDisposalsJson, BAD_REQUEST, emptyDisposalsError, None, Some("empty disposals")),
+          ("AA123456A", "2019-20", missingFieldsJson, BAD_REQUEST, missingFieldsError, None, Some("missing all mandatory fields")),
+          ("AA123456A", "2019-20", decimalsTooBigJson, BAD_REQUEST, DecimalsOutOfRangeError, None, Some("Decimals too big")),
+          ("AA123456A", "2019-20", decimalsTooSmallJson, BAD_REQUEST, DecimalsOutOfRangeError, None, Some("Decimals too small")),
+          ("AA123456A", "2019-20", datesNotFormattedJson, BAD_REQUEST, datesNotFormattedError, None, Some("incorrect date formats")),
+          ("AA123456A", "2019-20", customerRefTooLongJson, BAD_REQUEST, customerRefError, None, Some("bad customer reference")),
+          ("AA123456A", "2019-20", customerRefTooShortJson, BAD_REQUEST, customerRefError, None, Some("empty customer reference string")),
+          ("AA123456A", "2019-20", gainLossJson, BAD_REQUEST, gainLossError, None, Some("gain and loss provided"))
+        )
+        input.foreach(args => validationErrorTest.tupled(args))
+      }
+
+      "service error" when {
+        def serviceErrorTest(downstreamStatus: Int, downstreamCode: String, expectedStatus: Int, expectedBody: MtdError): Unit = {
+          s"downstream returns an $downstreamCode error and status $downstreamStatus" in new NonTysTest {
+
+            override def setupStubs(): StubMapping = {
+              AuditStub.audit()
+              AuthStub.authorised()
+              MtdIdLookupStub.ninoFound(nino)
+              DownstreamStub.onError(DownstreamStub.PUT, downstreamUri, downstreamStatus, errorBody(downstreamCode))
+            }
+
+            val response: WSResponse = await(request.put(validRequestJson))
+            response.status shouldBe expectedStatus
+            response.json shouldBe Json.toJson(expectedBody)
+            response.header("Content-Type") shouldBe Some("application/json")
+
+            verifyNrs(validRequestJson)
+          }
+        }
+
+        def errorBody(code: String): String =
+          s"""
+             |{
+             |   "code": "$code",
+             |   "reason": "ifs message"
+             |}
+            """.stripMargin
+
+        val errors = Seq(
+          (BAD_REQUEST, "INVALID_TAXABLE_ENTITY_ID", BAD_REQUEST, NinoFormatError),
+          (BAD_REQUEST, "INVALID_TAX_YEAR", BAD_REQUEST, TaxYearFormatError),
+          (BAD_REQUEST, "INVALID_CORRELATIONID", INTERNAL_SERVER_ERROR, InternalError),
+          (BAD_REQUEST, "INVALID_PAYLOAD", INTERNAL_SERVER_ERROR, InternalError),
+          (UNPROCESSABLE_ENTITY, "INVALID_DISPOSAL_DATE", BAD_REQUEST, RuleDisposalDateErrorV1),
+          (UNPROCESSABLE_ENTITY, "INVALID_COMPLETION_DATE", BAD_REQUEST, RuleCompletionDateError),
+          (UNPROCESSABLE_ENTITY, "INVALID_ACQUISITION_DATE", BAD_REQUEST, RuleAcquisitionDateAfterDisposalDateError),
+          (UNPROCESSABLE_ENTITY, "OUTSIDE_AMENDMENT_WINDOW", BAD_REQUEST, RuleOutsideAmendmentWindowError),
+          (INTERNAL_SERVER_ERROR, "SERVER_ERROR", INTERNAL_SERVER_ERROR, InternalError),
+          (SERVICE_UNAVAILABLE, "SERVICE_UNAVAILABLE", INTERNAL_SERVER_ERROR, InternalError)
+        )
+
+        val extraTysErrors = Seq(
+          (UNPROCESSABLE_ENTITY, "TAX_YEAR_NOT_SUPPORTED", BAD_REQUEST, RuleTaxYearNotSupportedError),
+          (BAD_REQUEST, "INVALID_CORRELATION_ID", INTERNAL_SERVER_ERROR, InternalError)
+        )
+
+        (errors ++ extraTysErrors).foreach(args => serviceErrorTest.tupled(args))
+      }
+    }
+  }
+
+}

--- a/it/test/v2/endpoints/CreateAmendOtherCgtControllerHipISpec.scala
+++ b/it/test/v2/endpoints/CreateAmendOtherCgtControllerHipISpec.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package v1.endpoints
+package v2.endpoints
 
 import com.github.tomakehurst.wiremock.client.WireMock.*
 import common.errors.*
@@ -28,7 +28,7 @@ import shared.models.errors.*
 import shared.services.*
 import shared.support.{IntegrationBaseSpec, WireMockMethods}
 
-class CreateAmendOtherCgtControllerISpec extends IntegrationBaseSpec with WireMockMethods {
+class CreateAmendOtherCgtControllerHipISpec extends IntegrationBaseSpec with WireMockMethods {
 
   val validRequestJson: JsValue = Json.parse(
     """
@@ -374,14 +374,14 @@ class CreateAmendOtherCgtControllerISpec extends IntegrationBaseSpec with WireMo
 
   }
 
-  private trait TysIfsTest extends Test {
+  private trait TysHipTest extends Test {
 
     override val taxYear: String = "2023-24"
 
     override def request: WSRequest =
       super.request.addHttpHeaders("suspend-temporal-validations" -> "true")
 
-    def downstreamUrl: String = s"/income-tax/income/disposals/other-gains/23-24/$nino"
+    def downstreamUrl: String = s"/itsa/income-tax/v1/23-24/income/disposals/other-gains/$nino"
 
   }
 
@@ -398,7 +398,7 @@ class CreateAmendOtherCgtControllerISpec extends IntegrationBaseSpec with WireMo
         verifyNrs(validRequestJson)
       }
 
-      "any valid request is made TYS" in new TysIfsTest {
+      "any valid request is made TYS" in new TysHipTest {
 
         override def setupStubs(): Unit = {
           DownstreamStub.onSuccess(DownstreamStub.PUT, downstreamUrl, NO_CONTENT, JsObject.empty)
@@ -437,6 +437,7 @@ class CreateAmendOtherCgtControllerISpec extends IntegrationBaseSpec with WireMo
           ("AA123456A", "20177", validRequestJson, BAD_REQUEST, TaxYearFormatError, None, None),
           ("AA123456A", "2015-17", validRequestJson, BAD_REQUEST, RuleTaxYearRangeInvalidError, None, None),
           ("AA123456A", "2018-19", validRequestJson, BAD_REQUEST, RuleTaxYearNotSupportedError, None, None),
+          ("AA123456A", "2025-26", validRequestJson, BAD_REQUEST, RuleTaxYearForVersionNotSupportedError, None, None),
 
           // Body errors
           ("AA123456A", "2021-22", JsObject.empty, BAD_REQUEST, RuleIncorrectOrEmptyBodyError, None, Some("emptyBody")),
@@ -454,7 +455,7 @@ class CreateAmendOtherCgtControllerISpec extends IntegrationBaseSpec with WireMo
 
       "downstream service error" when {
         def serviceErrorTest(downstreamStatus: Int, downstreamCode: String, expectedStatus: Int, expectedBody: MtdError): Unit = {
-          s"downstream returns an $downstreamCode error and status $downstreamStatus" in new TysIfsTest {
+          s"downstream returns an $downstreamCode error and status $downstreamStatus" in new TysHipTest {
 
             override def setupStubs(): Unit = {
               DownstreamStub.onError(DownstreamStub.PUT, downstreamUrl, downstreamStatus, errorBody(downstreamCode))
@@ -470,10 +471,17 @@ class CreateAmendOtherCgtControllerISpec extends IntegrationBaseSpec with WireMo
         def errorBody(code: String): String =
           s"""
              |{
-             |   "code": "$code",
-             |   "reason": "downstream message"
+             |  "origin": "HoD",
+             |  "response": {
+             |    "failures": [
+             |      {
+             |        "type": "$code",
+             |        "reason": "message"
+             |      }
+             |    ]
+             |  }
              |}
-            """.stripMargin
+                    """.stripMargin
 
         val errorInput = Seq(
           (BAD_REQUEST, "INVALID_TAXABLE_ENTITY_ID", BAD_REQUEST, NinoFormatError),

--- a/it/test/v2/endpoints/CreateAmendOtherCgtControllerIfsISpec.scala
+++ b/it/test/v2/endpoints/CreateAmendOtherCgtControllerIfsISpec.scala
@@ -1,0 +1,503 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v2.endpoints
+
+import com.github.tomakehurst.wiremock.client.WireMock.*
+import common.errors.*
+import play.api.http.HeaderNames.ACCEPT
+import play.api.http.Status.*
+import play.api.libs.json.{JsObject, JsValue, Json}
+import play.api.libs.ws.WSBodyWritables.writeableOf_JsValue
+import play.api.libs.ws.{WSRequest, WSResponse}
+import play.api.test.Helpers.AUTHORIZATION
+import shared.models.errors.*
+import shared.services.*
+import shared.support.{IntegrationBaseSpec, WireMockMethods}
+
+class CreateAmendOtherCgtControllerIfsISpec extends IntegrationBaseSpec with WireMockMethods {
+
+  override def servicesConfig: Map[String, Any] =
+    Map("feature-switch.ifs_hip_migration_1886.enabled" -> false) ++ super.servicesConfig
+
+  val validRequestJson: JsValue = Json.parse(
+    """
+      |{
+      |   "disposals":[
+      |      {
+      |         "assetType":"other-property",
+      |         "assetDescription":"string",
+      |         "acquisitionDate":"2021-05-07",
+      |         "disposalDate":"2021-05-07",
+      |         "disposalProceeds":59999999999.99,
+      |         "allowableCosts":59999999999.99,
+      |         "gain":59999999999.99,
+      |         "claimOrElectionCodes":[
+      |            "OTH"
+      |         ],
+      |         "gainAfterRelief":59999999999.99,
+      |         "rttTaxPaid":59999999999.99
+      |      }
+      |   ],
+      |   "nonStandardGains":{
+      |      "carriedInterestGain":19999999999.99,
+      |      "carriedInterestRttTaxPaid":19999999999.99,
+      |      "attributedGains":19999999999.99,
+      |      "attributedGainsRttTaxPaid":19999999999.99,
+      |      "otherGains":19999999999.99,
+      |      "otherGainsRttTaxPaid":19999999999.99
+      |   },
+      |   "losses":{
+      |      "broughtForwardLossesUsedInCurrentYear":29999999999.99,
+      |      "setAgainstInYearGains":29999999999.99,
+      |      "setAgainstInYearGeneralIncome":29999999999.99,
+      |      "setAgainstEarlierYear":29999999999.99
+      |   },
+      |   "adjustments":-39999999999.99
+      |}
+     """.stripMargin
+  )
+
+  val noMeaningfulDataJson: JsValue = Json.parse(
+    """
+      |{
+      |  "aField": "aValue"
+      |}
+       """.stripMargin
+  )
+
+  val emptyFieldsJson: JsValue = Json.parse(
+    """
+      |{
+      |   "disposals": [],
+      |   "nonStandardGains": {},
+      |   "losses": {}
+      |}
+     """.stripMargin
+  )
+
+  val emptyFieldsError: MtdError = RuleIncorrectOrEmptyBodyError.copy(
+    paths = Some(Seq("/disposals", "/nonStandardGains", "/losses"))
+  )
+
+  val missingFieldsJson: JsValue = Json.parse(
+    """
+      |{
+      |   "disposals": [{}]
+      |}
+     """.stripMargin
+  )
+
+  val missingFieldsError: MtdError = RuleIncorrectOrEmptyBodyError.copy(
+    paths = Some(
+      Seq(
+        "/disposals/0/acquisitionDate",
+        "/disposals/0/allowableCosts",
+        "/disposals/0/assetDescription",
+        "/disposals/0/assetType",
+        "/disposals/0/disposalDate",
+        "/disposals/0/disposalProceeds"
+      ))
+  )
+
+  val gainAndLossJson: JsValue = Json.parse(
+    """
+      |{
+      |   "disposals": [
+      |     {
+      |       "assetType":"other-property",
+      |       "assetDescription":"string",
+      |       "acquisitionDate":"2021-05-07",
+      |       "disposalDate":"2021-05-07",
+      |       "disposalProceeds":59999999999.99,
+      |       "allowableCosts":59999999999.99,
+      |       "gain":59999999999.99,
+      |       "loss":1234123.44,
+      |       "claimOrElectionCodes":[
+      |          "OTH"
+      |       ],
+      |       "gainAfterRelief":59999999999.99,
+      |       "lossAfterRelief":59999999999.99,
+      |       "rttTaxPaid":59999999999.99
+      |     }
+      |   ]
+      |}
+     """.stripMargin
+  )
+
+  val gainAndLossErrors: ErrorWrapper = ErrorWrapper(
+    correlationId = "",
+    BadRequestError,
+    Some(
+      Seq(
+        RuleGainAfterReliefLossAfterReliefError.copy(
+          paths = Some(
+            Seq(
+              "/disposals/0"
+            ))
+        ),
+        RuleGainLossError.copy(
+          paths = Some(
+            Seq(
+              "/disposals/0"
+            ))
+        )))
+  )
+
+  val decimalsTooBigJson: JsValue = Json.parse(
+    """
+      |{
+      |   "disposals":[
+      |      {
+      |         "assetType":"other-property",
+      |         "assetDescription":"string",
+      |         "acquisitionDate":"2021-05-07",
+      |         "disposalDate":"2021-05-07",
+      |         "disposalProceeds": 999999999999.99,
+      |         "allowableCosts": 999999999999.99,
+      |         "gain": 999999999999.99,
+      |         "claimOrElectionCodes":[
+      |            "OTH"
+      |         ],
+      |         "gainAfterRelief": 999999999999.99,
+      |         "rttTaxPaid": 999999999999.99
+      |      }
+      |   ],
+      |   "nonStandardGains":{
+      |      "carriedInterestGain": 999999999999.99,
+      |      "carriedInterestRttTaxPaid": 999999999999.99,
+      |      "attributedGains": 999999999999.99,
+      |      "attributedGainsRttTaxPaid": 999999999999.99,
+      |      "otherGains": 999999999999.99,
+      |      "otherGainsRttTaxPaid": 999999999999.99
+      |   },
+      |   "losses":{
+      |      "broughtForwardLossesUsedInCurrentYear": 999999999999.99,
+      |      "setAgainstInYearGains": 999999999999.99,
+      |      "setAgainstInYearGeneralIncome": 999999999999.99,
+      |      "setAgainstEarlierYear": 999999999999.99
+      |   },
+      |   "adjustments": 999999999999.99
+      |}
+     """.stripMargin
+  )
+
+  val decimalsTooSmallJson: JsValue = Json.parse(
+    """
+      |{
+      |   "disposals":[
+      |      {
+      |         "assetType":"other-property",
+      |         "assetDescription":"string",
+      |         "acquisitionDate":"2021-05-07",
+      |         "disposalDate":"2021-05-07",
+      |         "disposalProceeds": -0.01,
+      |         "allowableCosts": -0.01,
+      |         "gain": -0.01,
+      |         "claimOrElectionCodes":[
+      |            "OTH"
+      |         ],
+      |         "gainAfterRelief": -0.01,
+      |         "rttTaxPaid": -0.01
+      |      }
+      |   ],
+      |   "nonStandardGains":{
+      |      "carriedInterestGain": -0.01,
+      |      "carriedInterestRttTaxPaid": -0.01,
+      |      "attributedGains": -0.01,
+      |      "attributedGainsRttTaxPaid": -0.01,
+      |      "otherGains": -0.01,
+      |      "otherGainsRttTaxPaid": -0.01
+      |   },
+      |   "losses":{
+      |      "broughtForwardLossesUsedInCurrentYear": -0.01,
+      |      "setAgainstInYearGains": -0.01,
+      |      "setAgainstInYearGeneralIncome": -0.01,
+      |      "setAgainstEarlierYear": -0.01
+      |   },
+      |   "adjustments": -999999999999.99
+      |}
+     """.stripMargin
+  )
+
+  val positiveDecimalsOutOfRangeError: MtdError = ValueFormatError.copy(
+    message = "The value must be between 0 and 99999999999.99",
+    paths = Some(
+      Seq(
+        "/disposals/0/disposalProceeds",
+        "/disposals/0/allowableCosts",
+        "/disposals/0/gain",
+        "/disposals/0/gainAfterRelief",
+        "/disposals/0/rttTaxPaid",
+        "/nonStandardGains/carriedInterestGain",
+        "/nonStandardGains/carriedInterestRttTaxPaid",
+        "/nonStandardGains/attributedGains",
+        "/nonStandardGains/attributedGainsRttTaxPaid",
+        "/nonStandardGains/otherGains",
+        "/nonStandardGains/otherGainsRttTaxPaid",
+        "/losses/broughtForwardLossesUsedInCurrentYear",
+        "/losses/setAgainstInYearGains",
+        "/losses/setAgainstInYearGeneralIncome",
+        "/losses/setAgainstEarlierYear"
+      ))
+  )
+
+  val decimalsOutOfRangeErrors: ErrorWrapper = ErrorWrapper(
+    correlationId = "",
+    BadRequestError,
+    Some(
+      Seq(
+        positiveDecimalsOutOfRangeError,
+        ValueFormatError.copy(
+          message = "The value must be between -99999999999.99 and 99999999999.99",
+          paths = Some(
+            Seq(
+              "/adjustments"
+            ))
+        )
+      ))
+  )
+
+  val formatDisposalsJson: JsValue = Json.parse(
+    """
+      |{
+      |   "disposals":[
+      |      {
+      |         "assetType":"notEnumValue",
+      |         "assetDescription":"",
+      |         "acquisitionDate":"",
+      |         "disposalDate":"",
+      |         "disposalProceeds":59999999999.99,
+      |         "allowableCosts":59999999999.99,
+      |         "gain":59999999999.99,
+      |         "claimOrElectionCodes":[
+      |            "bip",
+      |            "bop"
+      |         ],
+      |         "gainAfterRelief":59999999999.99,
+      |         "rttTaxPaid":59999999999.99
+      |      }
+      |   ]
+      |}
+     """.stripMargin
+  )
+
+  val formatDisposalsErrors: ErrorWrapper = ErrorWrapper(
+    correlationId = "",
+    BadRequestError,
+    Some(
+      Seq(
+        AssetDescriptionFormatError.copy(
+          paths = Some(
+            Seq(
+              "/disposals/0/assetDescription"
+            ))
+        ),
+        AssetTypeFormatError.copy(
+          paths = Some(
+            Seq(
+              "/disposals/0/assetType"
+            ))
+        ),
+        ClaimOrElectionCodesFormatError.copy(
+          paths = Some(
+            Seq(
+              "/disposals/0/claimOrElectionCodes/0",
+              "/disposals/0/claimOrElectionCodes/1"
+            ))
+        ),
+        DateFormatError.copy(
+          paths = Some(
+            Seq(
+              "/disposals/0/disposalDate",
+              "/disposals/0/acquisitionDate"
+            ))
+        )
+      ))
+  )
+
+  val formatNonStandardGainsJson: JsValue = Json.parse(
+    """
+      |{
+      |   "nonStandardGains":{
+      |      "carriedInterestRttTaxPaid":19999999999.99,
+      |      "attributedGainsRttTaxPaid":19999999999.99,
+      |      "otherGainsRttTaxPaid":19999999999.99
+      |   }
+      |}
+     """.stripMargin
+  )
+
+  val formatNonStandardGainsError: MtdError = RuleIncorrectOrEmptyBodyError.copy(
+    paths = Some(Seq("/nonStandardGains"))
+  )
+
+  private trait Test {
+    val nino: String    = "AA123456A"
+    val taxYear: String = "2021-22"
+
+    def uri: String = s"/other-gains/$nino/$taxYear"
+
+    def setupStubs(): Unit = ()
+
+    def request: WSRequest = {
+      AuditStub.audit()
+      AuthStub.authorised()
+      MtdIdLookupStub.ninoFound(nino)
+      setupStubs()
+      buildRequest(uri)
+        .withHttpHeaders(
+          (ACCEPT, "application/vnd.hmrc.2.0+json"),
+          (AUTHORIZATION, "Bearer 123") // some bearer token
+        )
+    }
+
+    def verifyNrs(payload: JsValue): Unit =
+      verify(
+        postRequestedFor(urlEqualTo(s"/mtd-api-nrs-proxy/$nino/itsa-cgt-disposal-other"))
+          .withRequestBody(equalToJson(payload.toString())))
+
+  }
+
+  private trait NonTysTest extends Test {
+    def downstreamUrl: String = s"/income-tax/income/disposals/other-gains/$nino/$taxYear"
+
+  }
+
+  private trait TysIfsTest extends Test {
+
+    override val taxYear: String = "2023-24"
+
+    override def request: WSRequest =
+      super.request.addHttpHeaders("suspend-temporal-validations" -> "true")
+
+    def downstreamUrl: String = s"/income-tax/income/disposals/other-gains/23-24/$nino"
+
+  }
+
+  "Calling the 'create and amend other CGT' endpoint" should {
+    "return a 200 status code" when {
+      "any valid request is made" in new NonTysTest {
+
+        override def setupStubs(): Unit = {
+          DownstreamStub.onSuccess(DownstreamStub.PUT, downstreamUrl, NO_CONTENT, JsObject.empty)
+        }
+
+        val response: WSResponse = await(request.put(validRequestJson))
+        response.status shouldBe OK
+        verifyNrs(validRequestJson)
+      }
+
+      "any valid request is made TYS" in new TysIfsTest {
+
+        override def setupStubs(): Unit = {
+          DownstreamStub.onSuccess(DownstreamStub.PUT, downstreamUrl, NO_CONTENT, JsObject.empty)
+        }
+
+        val response: WSResponse = await(request.put(validRequestJson))
+        response.status shouldBe OK
+        verifyNrs(validRequestJson)
+      }
+    }
+
+    "return error according to spec" when {
+      "validation error" when {
+        def validationErrorTest(requestNino: String,
+                                requestTaxYear: String,
+                                requestBody: JsValue,
+                                expectedStatus: Int,
+                                expectedError: MtdError,
+                                expectedErrors: Option[ErrorWrapper],
+                                scenario: Option[String]): Unit = {
+          s"validation fails with ${expectedError.code} error${scenario.fold("")(scenario => s" for $scenario scenario")}" in new NonTysTest {
+
+            override val nino: String    = requestNino
+            override val taxYear: String = requestTaxYear
+
+            val response: WSResponse = await(request.put(requestBody))
+            response.status shouldBe expectedStatus
+            response.json shouldBe expectedErrors.fold(Json.toJson(expectedError))(errorWrapper => Json.toJson(errorWrapper))
+            response.header("Content-Type") shouldBe Some("application/json")
+          }
+        }
+
+        val input = Seq(
+          // Path errors
+          ("AA1123A", "2019-20", validRequestJson, BAD_REQUEST, NinoFormatError, None, None),
+          ("AA123456A", "20177", validRequestJson, BAD_REQUEST, TaxYearFormatError, None, None),
+          ("AA123456A", "2015-17", validRequestJson, BAD_REQUEST, RuleTaxYearRangeInvalidError, None, None),
+          ("AA123456A", "2018-19", validRequestJson, BAD_REQUEST, RuleTaxYearNotSupportedError, None, None),
+          ("AA123456A", "2025-26", validRequestJson, BAD_REQUEST, RuleTaxYearForVersionNotSupportedError, None, None),
+
+          // Body errors
+          ("AA123456A", "2021-22", JsObject.empty, BAD_REQUEST, RuleIncorrectOrEmptyBodyError, None, Some("emptyBody")),
+          ("AA123456A", "2021-22", noMeaningfulDataJson, BAD_REQUEST, RuleIncorrectOrEmptyBodyError, None, Some("nonsenseBody")),
+          ("AA123456A", "2021-22", emptyFieldsJson, BAD_REQUEST, emptyFieldsError, None, Some("emptyFields")),
+          ("AA123456A", "2021-22", missingFieldsJson, BAD_REQUEST, missingFieldsError, None, Some("missingFields")),
+          ("AA123456A", "2021-22", gainAndLossJson, BAD_REQUEST, BadRequestError, Some(gainAndLossErrors), Some("gainAndLossRule")),
+          ("AA123456A", "2021-22", decimalsTooBigJson, BAD_REQUEST, BadRequestError, Some(decimalsOutOfRangeErrors), Some("decimalsTooBig")),
+          ("AA123456A", "2021-22", decimalsTooSmallJson, BAD_REQUEST, BadRequestError, Some(decimalsOutOfRangeErrors), Some("decimalsTooSmall")),
+          ("AA123456A", "2021-22", formatDisposalsJson, BAD_REQUEST, BadRequestError, Some(formatDisposalsErrors), Some("formatDisposals")),
+          ("AA123456A", "2021-22", formatNonStandardGainsJson, BAD_REQUEST, formatNonStandardGainsError, None, Some("formatNonStandardGains"))
+        )
+        input.foreach(args => (validationErrorTest).tupled(args))
+      }
+
+      "downstream service error" when {
+        def serviceErrorTest(downstreamStatus: Int, downstreamCode: String, expectedStatus: Int, expectedBody: MtdError): Unit = {
+          s"downstream returns an $downstreamCode error and status $downstreamStatus" in new TysIfsTest {
+
+            override def setupStubs(): Unit = {
+              DownstreamStub.onError(DownstreamStub.PUT, downstreamUrl, downstreamStatus, errorBody(downstreamCode))
+            }
+
+            val response: WSResponse = await(request.put(validRequestJson))
+            response.status shouldBe expectedStatus
+            response.json shouldBe Json.toJson(expectedBody)
+            response.header("Content-Type") shouldBe Some("application/json")
+          }
+        }
+
+        def errorBody(code: String): String =
+          s"""
+             |{
+             |   "code": "$code",
+             |   "reason": "downstream message"
+             |}
+            """.stripMargin
+
+        val errorInput = Seq(
+          (BAD_REQUEST, "INVALID_TAXABLE_ENTITY_ID", BAD_REQUEST, NinoFormatError),
+          (BAD_REQUEST, "INVALID_TAX_YEAR", BAD_REQUEST, TaxYearFormatError),
+          (BAD_REQUEST, "INVALID_PAYLOAD", INTERNAL_SERVER_ERROR, InternalError),
+          (BAD_REQUEST, "INVALID_CORRELATIONID", INTERNAL_SERVER_ERROR, InternalError),
+          (UNPROCESSABLE_ENTITY, "INVALID_DISPOSAL_DATE", BAD_REQUEST, RuleDisposalDateNotFutureError),
+          (UNPROCESSABLE_ENTITY, "INVALID_ACQUISITION_DATE", BAD_REQUEST, RuleAcquisitionDateError),
+          (UNPROCESSABLE_ENTITY, "OUTSIDE_AMENDMENT_WINDOW", BAD_REQUEST, RuleOutsideAmendmentWindowError),
+          (INTERNAL_SERVER_ERROR, "SERVER_ERROR", INTERNAL_SERVER_ERROR, InternalError),
+          (SERVICE_UNAVAILABLE, "SERVICE_UNAVAILABLE", INTERNAL_SERVER_ERROR, InternalError)
+        )
+
+        val tysErrorInput = Seq(
+          (BAD_REQUEST, "INVALID_CORRELATION_ID", INTERNAL_SERVER_ERROR, InternalError),
+          (UNPROCESSABLE_ENTITY, "TAX_YEAR_NOT_SUPPORTED", BAD_REQUEST, RuleTaxYearNotSupportedError)
+        )
+        (errorInput ++ tysErrorInput).foreach(args => (serviceErrorTest).tupled(args))
+      }
+    }
+  }
+
+}

--- a/it/test/v2/endpoints/DeleteCgtNonPpdControllerHipISpec.scala
+++ b/it/test/v2/endpoints/DeleteCgtNonPpdControllerHipISpec.scala
@@ -27,24 +27,12 @@ import shared.models.errors.*
 import shared.services.{AuthStub, DownstreamStub, MtdIdLookupStub}
 import shared.support.IntegrationBaseSpec
 
-class DeleteCgtNonPpdControllerISpec extends IntegrationBaseSpec {
+class DeleteCgtNonPpdControllerHipISpec extends IntegrationBaseSpec {
 
   "Calling the 'delete cgt non-ppd disposals' endpoint" should {
     "return a 204 status code" when {
-      "any valid request is made" in new NonTysTest {
 
-        override def setupStubs(): Unit = {
-          DownstreamStub.onSuccess(DownstreamStub.DELETE, downstreamUri, NO_CONTENT)
-        }
-
-        val response: WSResponse = await(request().delete())
-        response.status shouldBe NO_CONTENT
-        response.body shouldBe ""
-        response.header("Content-Type") shouldBe None
-        response.header("X-CorrelationId").nonEmpty shouldBe true
-      }
-
-      "any valid request is made for a Tax Year Specific (TYS) tax year" in new TysIfsTest {
+      "any valid request is made for a Tax Year Specific (TYS) tax year" in new Test {
 
         override def setupStubs(): Unit = {
           DownstreamStub.onSuccess(DownstreamStub.DELETE, downstreamUri, NO_CONTENT)
@@ -62,7 +50,7 @@ class DeleteCgtNonPpdControllerISpec extends IntegrationBaseSpec {
 
       "validation error" when {
         def validationErrorTest(requestNino: String, requestTaxYear: String, expectedStatus: Int, expectedBody: MtdError): Unit = {
-          s"validation fails with ${expectedBody.code} error" in new NonTysTest {
+          s"validation fails with ${expectedBody.code} error" in new Test {
 
             override val nino: String    = requestNino
             override val taxYear: String = requestTaxYear
@@ -77,17 +65,18 @@ class DeleteCgtNonPpdControllerISpec extends IntegrationBaseSpec {
         }
 
         val input = Seq(
-          ("AA1123A", "2019-20", BAD_REQUEST, NinoFormatError),
+          ("AA1123A", "2023-24", BAD_REQUEST, NinoFormatError),
           ("AA123456A", "20199", BAD_REQUEST, TaxYearFormatError),
           ("AA123456A", "2018-19", BAD_REQUEST, RuleTaxYearNotSupportedError),
+          ("AA123456A", "2025-26", BAD_REQUEST, RuleTaxYearForVersionNotSupportedError),
           ("AA123456A", "2019-21", BAD_REQUEST, RuleTaxYearRangeInvalidError)
         )
-        input.foreach(args => (validationErrorTest).tupled(args))
+        input.foreach(args => validationErrorTest.tupled(args))
       }
 
       "downstream service error" when {
         def serviceErrorTest(downstreamStatus: Int, downstreamCode: String, expectedStatus: Int, expectedBody: MtdError): Unit = {
-          s"downstream returns an $downstreamCode error and status $downstreamStatus" in new NonTysTest {
+          s"downstream returns an $downstreamCode error and status $downstreamStatus" in new Test {
 
             override def setupStubs(): Unit = {
               DownstreamStub.onError(DownstreamStub.DELETE, downstreamUri, downstreamStatus, errorBody(downstreamCode))
@@ -100,31 +89,33 @@ class DeleteCgtNonPpdControllerISpec extends IntegrationBaseSpec {
           }
         }
 
-        def errorBody(code: String): String =
+        def errorBody(`type`: String): String =
           s"""
              |{
-             |   "code": "$code",
-             |   "reason": "downstream message"
+             |  "origin": "HoD",
+             |  "response": {
+             |    "failures": [
+             |      {
+             |        "type": "${`type`}",
+             |        "reason": "downstream message"
+             |      }
+             |    ]
+             |  }
              |}
-            """.stripMargin
+        """.stripMargin
 
         val errors = List(
           (BAD_REQUEST, "INVALID_TAXABLE_ENTITY_ID", BAD_REQUEST, NinoFormatError),
           (BAD_REQUEST, "INVALID_TAX_YEAR", BAD_REQUEST, TaxYearFormatError),
-          (BAD_REQUEST, "INVALID_CORRELATIONID", INTERNAL_SERVER_ERROR, InternalError),
-          (NOT_FOUND, "NO_DATA_FOUND", NOT_FOUND, NotFoundError),
-          (INTERNAL_SERVER_ERROR, "SERVER_ERROR", INTERNAL_SERVER_ERROR, InternalError),
-          (SERVICE_UNAVAILABLE, "SERVICE_UNAVAILABLE", INTERNAL_SERVER_ERROR, InternalError)
-        )
-
-        val extraTysErrors = List(
           (BAD_REQUEST, "INVALID_CORRELATION_ID", INTERNAL_SERVER_ERROR, InternalError),
           (NOT_FOUND, "NOT_FOUND", NOT_FOUND, NotFoundError),
+          (INTERNAL_SERVER_ERROR, "SERVER_ERROR", INTERNAL_SERVER_ERROR, InternalError),
+          (SERVICE_UNAVAILABLE, "SERVICE_UNAVAILABLE", INTERNAL_SERVER_ERROR, InternalError),
           (UNPROCESSABLE_ENTITY, "TAX_YEAR_NOT_SUPPORTED", BAD_REQUEST, RuleTaxYearNotSupportedError),
           (UNPROCESSABLE_ENTITY, "OUTSIDE_AMENDMENT_WINDOW", BAD_REQUEST, RuleOutsideAmendmentWindowError)
         )
 
-        (errors ++ extraTysErrors).foreach(args => (serviceErrorTest).tupled(args))
+        errors.foreach(args => serviceErrorTest.tupled(args))
       }
     }
   }
@@ -134,8 +125,8 @@ class DeleteCgtNonPpdControllerISpec extends IntegrationBaseSpec {
     val nino: String   = "AA123456A"
     def mtdUri: String = s"/residential-property/$nino/$taxYear"
 
-    def taxYear: String
-    def downstreamUri: String
+    def taxYear: String       = "2023-24"
+    def downstreamUri: String = s"/itsa/income-tax/v1/23-24/income/disposals/residential-property/$nino"
 
     def setupStubs(): Unit
 
@@ -147,22 +138,10 @@ class DeleteCgtNonPpdControllerISpec extends IntegrationBaseSpec {
       buildRequest(mtdUri)
         .withHttpHeaders(
           (ACCEPT, "application/vnd.hmrc.2.0+json"),
-          (AUTHORIZATION, "Bearer 123") // some bearer token
+          (AUTHORIZATION, "Bearer 123")
         )
     }
 
-  }
-
-  private trait NonTysTest extends Test {
-    def taxYear: String = "2019-20"
-
-    def downstreamUri: String = s"/income-tax/income/disposals/residential-property/$nino/$taxYear"
-  }
-
-  private trait TysIfsTest extends Test {
-    def taxYear: String = "2023-24"
-
-    def downstreamUri: String = s"/income-tax/income/disposals/residential-property/23-24/$nino"
   }
 
 }

--- a/it/test/v2/endpoints/DeleteCgtNonPpdControllerIfsISpec.scala
+++ b/it/test/v2/endpoints/DeleteCgtNonPpdControllerIfsISpec.scala
@@ -1,0 +1,172 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v2.endpoints
+
+import common.errors.RuleOutsideAmendmentWindowError
+import play.api.http.HeaderNames.ACCEPT
+import play.api.http.Status.*
+import play.api.libs.json.Json
+import play.api.libs.ws.DefaultBodyReadables.readableAsString
+import play.api.libs.ws.{WSRequest, WSResponse}
+import play.api.test.Helpers.AUTHORIZATION
+import shared.models.errors.*
+import shared.services.{AuthStub, DownstreamStub, MtdIdLookupStub}
+import shared.support.IntegrationBaseSpec
+
+class DeleteCgtNonPpdControllerIfsISpec extends IntegrationBaseSpec {
+
+  override def servicesConfig: Map[String, Any] =
+    Map("feature-switch.ifs_hip_migration_1875.enabled" -> false) ++ super.servicesConfig
+
+  "Calling the 'delete cgt non-ppd disposals' endpoint" should {
+    "return a 204 status code" when {
+      "any valid request is made" in new NonTysTest {
+
+        override def setupStubs(): Unit = {
+          DownstreamStub.onSuccess(DownstreamStub.DELETE, downstreamUri, NO_CONTENT)
+        }
+
+        val response: WSResponse = await(request().delete())
+        response.status shouldBe NO_CONTENT
+        response.body shouldBe ""
+        response.header("Content-Type") shouldBe None
+        response.header("X-CorrelationId").nonEmpty shouldBe true
+      }
+
+      "any valid request is made for a Tax Year Specific (TYS) tax year" in new TysIfsTest {
+
+        override def setupStubs(): Unit = {
+          DownstreamStub.onSuccess(DownstreamStub.DELETE, downstreamUri, NO_CONTENT)
+        }
+
+        val response: WSResponse = await(request().delete())
+        response.status shouldBe NO_CONTENT
+        response.body shouldBe ""
+        response.header("Content-Type") shouldBe None
+        response.header("X-CorrelationId").nonEmpty shouldBe true
+      }
+    }
+
+    "return error according to spec" when {
+
+      "validation error" when {
+        def validationErrorTest(requestNino: String, requestTaxYear: String, expectedStatus: Int, expectedBody: MtdError): Unit = {
+          s"validation fails with ${expectedBody.code} error" in new NonTysTest {
+
+            override val nino: String    = requestNino
+            override val taxYear: String = requestTaxYear
+
+            override def setupStubs(): Unit = {}
+
+            val response: WSResponse = await(request().delete())
+            response.status shouldBe expectedStatus
+            response.json shouldBe Json.toJson(expectedBody)
+            response.header("Content-Type") shouldBe Some("application/json")
+          }
+        }
+
+        val input = Seq(
+          ("AA1123A", "2019-20", BAD_REQUEST, NinoFormatError),
+          ("AA123456A", "20199", BAD_REQUEST, TaxYearFormatError),
+          ("AA123456A", "2018-19", BAD_REQUEST, RuleTaxYearNotSupportedError),
+          ("AA123456A", "2025-26", BAD_REQUEST, RuleTaxYearForVersionNotSupportedError),
+          ("AA123456A", "2019-21", BAD_REQUEST, RuleTaxYearRangeInvalidError)
+        )
+        input.foreach(args => validationErrorTest.tupled(args))
+      }
+
+      "downstream service error" when {
+        def serviceErrorTest(downstreamStatus: Int, downstreamCode: String, expectedStatus: Int, expectedBody: MtdError): Unit = {
+          s"downstream returns an $downstreamCode error and status $downstreamStatus" in new NonTysTest {
+
+            override def setupStubs(): Unit = {
+              DownstreamStub.onError(DownstreamStub.DELETE, downstreamUri, downstreamStatus, errorBody(downstreamCode))
+            }
+
+            val response: WSResponse = await(request().delete())
+            response.status shouldBe expectedStatus
+            response.json shouldBe Json.toJson(expectedBody)
+            response.header("Content-Type") shouldBe Some("application/json")
+          }
+        }
+
+        def errorBody(code: String): String =
+          s"""
+             |{
+             |   "code": "$code",
+             |   "reason": "downstream message"
+             |}
+            """.stripMargin
+
+        val errors = List(
+          (BAD_REQUEST, "INVALID_TAXABLE_ENTITY_ID", BAD_REQUEST, NinoFormatError),
+          (BAD_REQUEST, "INVALID_TAX_YEAR", BAD_REQUEST, TaxYearFormatError),
+          (BAD_REQUEST, "INVALID_CORRELATIONID", INTERNAL_SERVER_ERROR, InternalError),
+          (NOT_FOUND, "NO_DATA_FOUND", NOT_FOUND, NotFoundError),
+          (INTERNAL_SERVER_ERROR, "SERVER_ERROR", INTERNAL_SERVER_ERROR, InternalError),
+          (SERVICE_UNAVAILABLE, "SERVICE_UNAVAILABLE", INTERNAL_SERVER_ERROR, InternalError)
+        )
+
+        val extraTysErrors = List(
+          (BAD_REQUEST, "INVALID_CORRELATION_ID", INTERNAL_SERVER_ERROR, InternalError),
+          (NOT_FOUND, "NOT_FOUND", NOT_FOUND, NotFoundError),
+          (UNPROCESSABLE_ENTITY, "TAX_YEAR_NOT_SUPPORTED", BAD_REQUEST, RuleTaxYearNotSupportedError),
+          (UNPROCESSABLE_ENTITY, "OUTSIDE_AMENDMENT_WINDOW", BAD_REQUEST, RuleOutsideAmendmentWindowError)
+        )
+
+        (errors ++ extraTysErrors).foreach(args => serviceErrorTest.tupled(args))
+      }
+    }
+  }
+
+  private trait Test {
+
+    val nino: String   = "AA123456A"
+    def mtdUri: String = s"/residential-property/$nino/$taxYear"
+
+    def taxYear: String
+    def downstreamUri: String
+
+    def setupStubs(): Unit
+
+    def request(): WSRequest = {
+      AuthStub.authorised()
+      MtdIdLookupStub.ninoFound(nino)
+      setupStubs()
+
+      buildRequest(mtdUri)
+        .withHttpHeaders(
+          (ACCEPT, "application/vnd.hmrc.2.0+json"),
+          (AUTHORIZATION, "Bearer 123") // some bearer token
+        )
+    }
+
+  }
+
+  private trait NonTysTest extends Test {
+    def taxYear: String = "2019-20"
+
+    def downstreamUri: String = s"/income-tax/income/disposals/residential-property/$nino/$taxYear"
+  }
+
+  private trait TysIfsTest extends Test {
+    def taxYear: String = "2023-24"
+
+    def downstreamUri: String = s"/income-tax/income/disposals/residential-property/23-24/$nino"
+  }
+
+}

--- a/it/test/v2/endpoints/DeleteCgtPpdOverridesControllerIfsISpec.scala
+++ b/it/test/v2/endpoints/DeleteCgtPpdOverridesControllerIfsISpec.scala
@@ -1,0 +1,175 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v2.endpoints
+
+import com.github.tomakehurst.wiremock.stubbing.StubMapping
+import common.errors.RuleOutsideAmendmentWindowError
+import play.api.http.HeaderNames.ACCEPT
+import play.api.http.Status.*
+import play.api.libs.json.Json
+import play.api.libs.ws.DefaultBodyReadables.readableAsString
+import play.api.libs.ws.{WSRequest, WSResponse}
+import play.api.test.Helpers.AUTHORIZATION
+import shared.models.errors.*
+import shared.services.*
+import shared.support.IntegrationBaseSpec
+
+class DeleteCgtPpdOverridesControllerIfsISpec extends IntegrationBaseSpec {
+
+  override def servicesConfig: Map[String, Any] =
+    Map("feature-switch.ifs_hip_migration_1947.enabled" -> false) ++ super.servicesConfig
+
+  private trait Test {
+
+    val nino: String = "AA123456A"
+
+    def taxYear: String
+    def downstreamUri: String
+
+    def uri: String = s"/residential-property/$nino/$taxYear/ppd"
+
+    def setupStubs(): StubMapping
+
+    def request(): WSRequest = {
+      setupStubs()
+      buildRequest(uri)
+        .withHttpHeaders(
+          (ACCEPT, "application/vnd.hmrc.2.0+json"),
+          (AUTHORIZATION, "Bearer 123") // some bearer token
+        )
+    }
+
+  }
+
+  private trait NonTysTest extends Test {
+    def taxYear: String       = "2019-20"
+    def downstreamUri: String = s"/income-tax/income/disposals/residential-property/ppd/$nino/$taxYear"
+  }
+
+  private trait TysIfsTest extends Test {
+    def taxYear: String       = "2023-24"
+    def downstreamUri: String = s"/income-tax/income/disposals/residential-property/ppd/23-24/$nino"
+  }
+
+  "Calling the 'delete cgt ppd overrides' endpoint" should {
+    "return a 204 status code" when {
+      "any valid request is made" in new NonTysTest {
+
+        override def setupStubs(): StubMapping = {
+          AuthStub.authorised()
+          MtdIdLookupStub.ninoFound(nino)
+          DownstreamStub.onSuccess(DownstreamStub.DELETE, downstreamUri, NO_CONTENT)
+        }
+
+        val response: WSResponse = await(request().delete())
+        response.status shouldBe NO_CONTENT
+        response.body shouldBe ""
+        response.header("Content-Type") shouldBe None
+        response.header("X-CorrelationId").nonEmpty shouldBe true
+      }
+
+      "any valid request is made for a Tax Year Specific (TYS) tax year" in new TysIfsTest {
+
+        override def setupStubs(): StubMapping = {
+          AuthStub.authorised()
+          MtdIdLookupStub.ninoFound(nino)
+          DownstreamStub.onSuccess(DownstreamStub.DELETE, downstreamUri, NO_CONTENT)
+        }
+
+        val response: WSResponse = await(request().delete())
+        response.status shouldBe NO_CONTENT
+        response.body shouldBe ""
+        response.header("Content-Type") shouldBe None
+        response.header("X-CorrelationId").nonEmpty shouldBe true
+      }
+    }
+
+    "return error according to spec" when {
+
+      "validation error" when {
+        def validationErrorTest(requestNino: String, requestTaxYear: String, expectedStatus: Int, expectedBody: MtdError): Unit = {
+          s"validation fails with ${expectedBody.code} error" in new NonTysTest {
+
+            override val nino: String    = requestNino
+            override val taxYear: String = requestTaxYear
+
+            override def setupStubs(): StubMapping = {
+              AuthStub.authorised()
+              MtdIdLookupStub.ninoFound(nino)
+            }
+
+            val response: WSResponse = await(request().delete())
+            response.status shouldBe expectedStatus
+            response.json shouldBe Json.toJson(expectedBody)
+            response.header("Content-Type") shouldBe Some("application/json")
+          }
+        }
+
+        val input = Seq(
+          ("AA1123A", "2019-20", BAD_REQUEST, NinoFormatError),
+          ("AA123456A", "20199", BAD_REQUEST, TaxYearFormatError),
+          ("AA123456A", "2018-19", BAD_REQUEST, RuleTaxYearNotSupportedError),
+          ("AA123456A", "2025-26", BAD_REQUEST, RuleTaxYearForVersionNotSupportedError),
+          ("AA123456A", "2019-21", BAD_REQUEST, RuleTaxYearRangeInvalidError)
+        )
+        input.foreach(args => (validationErrorTest).tupled(args))
+      }
+
+      "downstream service error" when {
+        def serviceErrorTest(downstreamStatus: Int, downstreamCode: String, expectedStatus: Int, expectedBody: MtdError): Unit = {
+          s"downstream returns an $downstreamCode error and status $downstreamStatus" in new NonTysTest {
+
+            override def setupStubs(): StubMapping = {
+              AuthStub.authorised()
+              MtdIdLookupStub.ninoFound(nino)
+              DownstreamStub.onError(DownstreamStub.DELETE, downstreamUri, downstreamStatus, errorBody(downstreamCode))
+            }
+
+            val response: WSResponse = await(request().delete())
+            response.status shouldBe expectedStatus
+            response.json shouldBe Json.toJson(expectedBody)
+            response.header("Content-Type") shouldBe Some("application/json")
+          }
+        }
+
+        def errorBody(code: String): String =
+          s"""
+             |{
+             |   "code": "$code",
+             |   "reason": "downstream message"
+             |}
+            """.stripMargin
+
+        val errors = Seq(
+          (BAD_REQUEST, "INVALID_TAXABLE_ENTITY_ID", BAD_REQUEST, NinoFormatError),
+          (BAD_REQUEST, "INVALID_TAX_YEAR", BAD_REQUEST, TaxYearFormatError),
+          (BAD_REQUEST, "INVALID_CORRELATIONID", INTERNAL_SERVER_ERROR, InternalError),
+          (NOT_FOUND, "NO_DATA_FOUND", NOT_FOUND, NotFoundError),
+          (INTERNAL_SERVER_ERROR, "SERVER_ERROR", INTERNAL_SERVER_ERROR, InternalError),
+          (SERVICE_UNAVAILABLE, "SERVICE_UNAVAILABLE", INTERNAL_SERVER_ERROR, InternalError)
+        )
+        val extraTysErrors = Seq(
+          (UNPROCESSABLE_ENTITY, "TAX_YEAR_NOT_SUPPORTED", BAD_REQUEST, RuleTaxYearNotSupportedError),
+          (UNPROCESSABLE_ENTITY, "OUTSIDE_AMENDMENT_WINDOW", BAD_REQUEST, RuleOutsideAmendmentWindowError)
+        )
+
+        (errors ++ extraTysErrors).foreach(args => (serviceErrorTest).tupled(args))
+      }
+    }
+  }
+
+}

--- a/it/test/v2/endpoints/RetrieveAllResidentialPropertyCgtControllerIfsISpec.scala
+++ b/it/test/v2/endpoints/RetrieveAllResidentialPropertyCgtControllerIfsISpec.scala
@@ -1,0 +1,207 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v2.endpoints
+
+import com.github.tomakehurst.wiremock.stubbing.StubMapping
+import common.errors.SourceFormatError
+import play.api.http.HeaderNames.ACCEPT
+import play.api.http.Status.*
+import play.api.libs.json.{JsValue, Json}
+import play.api.libs.ws.{WSRequest, WSResponse}
+import play.api.test.Helpers.AUTHORIZATION
+import shared.models.errors.*
+import shared.services.*
+import shared.support.IntegrationBaseSpec
+import v1.residentialPropertyDisposals.retrieveAll.def1.fixture.Def1_RetrieveAllResidentialPropertyCgtControllerFixture
+
+class RetrieveAllResidentialPropertyCgtControllerIfsISpec extends IntegrationBaseSpec {
+
+  override def servicesConfig: Map[String, Any] =
+    super.servicesConfig ++ Map("feature-switch.ifs_hip_migration_1881.enabled" -> false)
+
+  private trait Test {
+
+    def nino: String           = "AA123456A"
+    def source: Option[String] = Some("latest")
+
+    def taxYear: String
+
+    def downstreamUri: String
+    val downstreamResponse: JsValue = Def1_RetrieveAllResidentialPropertyCgtControllerFixture.ifsJson
+
+    def mtdUri: String       = s"/residential-property/$nino/$taxYear"
+    val mtdResponse: JsValue = Def1_RetrieveAllResidentialPropertyCgtControllerFixture.mtdJson
+
+    def mtdQueryParams: Seq[(String, String)] =
+      Seq("source" -> source)
+        .collect { case (k, Some(v)) =>
+          (k, v)
+        }
+
+    def setupStubs(): StubMapping
+
+    def mtdRequest: WSRequest = {
+      setupStubs()
+      buildRequest(mtdUri)
+        .addQueryStringParameters(mtdQueryParams*)
+        .withHttpHeaders(
+          (ACCEPT, "application/vnd.hmrc.2.0+json"),
+          (AUTHORIZATION, "Bearer 123") // some bearer token
+        )
+    }
+
+  }
+
+  private trait NonTysTest extends Test {
+    def taxYear: String       = "2020-21"
+    def downstreamUri: String = s"/income-tax/income/disposals/residential-property/$nino/2020-21"
+  }
+
+  private trait TysIfsTest extends Test {
+    def taxYear: String       = "2023-24"
+    def downstreamUri: String = s"/income-tax/income/disposals/residential-property/23-24/$nino"
+  }
+
+  "Calling the 'retrieve all residential property cgt' endpoint" should {
+    "return a 200 status code" when {
+      "any valid request is made" in new NonTysTest {
+
+        override def setupStubs(): StubMapping = {
+          AuditStub.audit()
+          AuthStub.authorised()
+          MtdIdLookupStub.ninoFound(nino)
+          DownstreamStub.onSuccess(DownstreamStub.GET, downstreamUri, Map("view" -> "LATEST"), OK, downstreamResponse)
+        }
+
+        val response: WSResponse = await(mtdRequest.get())
+        response.status shouldBe OK
+        response.json shouldBe mtdResponse
+        response.header("Content-Type") shouldBe Some("application/json")
+      }
+
+      "any valid request is made for Tax Year Specific (TYS)" in new TysIfsTest {
+
+        override def setupStubs(): StubMapping = {
+          AuditStub.audit()
+          AuthStub.authorised()
+          MtdIdLookupStub.ninoFound(nino)
+          DownstreamStub.onSuccess(DownstreamStub.GET, downstreamUri, Map("view" -> "LATEST"), OK, downstreamResponse)
+        }
+
+        val response: WSResponse = await(mtdRequest.get())
+        response.status shouldBe OK
+        response.json shouldBe mtdResponse
+        response.header("Content-Type") shouldBe Some("application/json")
+      }
+
+      "any valid request is made without source" in new NonTysTest {
+        override def source: Option[String] = None
+
+        override def setupStubs(): StubMapping = {
+          AuditStub.audit()
+          AuthStub.authorised()
+          MtdIdLookupStub.ninoFound(nino)
+          DownstreamStub.onSuccess(DownstreamStub.GET, downstreamUri, Map("view" -> "LATEST"), OK, downstreamResponse)
+        }
+
+        val response: WSResponse = await(mtdRequest.get())
+        response.status shouldBe OK
+        response.json shouldBe mtdResponse
+        response.header("Content-Type") shouldBe Some("application/json")
+      }
+    }
+
+    "return error according to spec" when {
+
+      "validation error" when {
+        def validationErrorTest(requestNino: String,
+                                requestTaxYear: String,
+                                requestSource: String,
+                                expectedStatus: Int,
+                                expectedBody: MtdError): Unit = {
+          s"validation fails with ${expectedBody.code} error" in new NonTysTest {
+
+            override val nino: String           = requestNino
+            override val taxYear: String        = requestTaxYear
+            override val source: Option[String] = Some(requestSource)
+
+            override def setupStubs(): StubMapping = {
+              AuditStub.audit()
+              AuthStub.authorised()
+              MtdIdLookupStub.ninoFound(nino)
+            }
+
+            val response: WSResponse = await(mtdRequest.get())
+            response.status shouldBe expectedStatus
+            response.json shouldBe Json.toJson(expectedBody)
+            response.header("Content-Type") shouldBe Some("application/json")
+          }
+        }
+
+        val input = Seq(
+          ("AA1123A", "2019-20", "latest", BAD_REQUEST, NinoFormatError),
+          ("AA123456A", "20177", "latest", BAD_REQUEST, TaxYearFormatError),
+          ("AA123456A", "2015-17", "latest", BAD_REQUEST, RuleTaxYearRangeInvalidError),
+          ("AA123456A", "2015-16", "latest", BAD_REQUEST, RuleTaxYearNotSupportedError),
+          ("AA123456A", "2025-26", "latest", BAD_REQUEST, RuleTaxYearForVersionNotSupportedError),
+          ("AA123456A", "2019-20", "test", BAD_REQUEST, SourceFormatError)
+        )
+        input.foreach(args => (validationErrorTest).tupled(args))
+      }
+
+      "downstream service error" when {
+        def serviceErrorTest(downstreamStatus: Int, downstreamCode: String, expectedStatus: Int, expectedBody: MtdError): Unit = {
+          s"downstream returns an $downstreamCode error and status $downstreamStatus" in new NonTysTest {
+
+            override def setupStubs(): StubMapping = {
+              AuditStub.audit()
+              AuthStub.authorised()
+              MtdIdLookupStub.ninoFound(nino)
+              DownstreamStub.onError(DownstreamStub.GET, downstreamUri, Map("view" -> "LATEST"), downstreamStatus, errorBody(downstreamCode))
+            }
+
+            val response: WSResponse = await(mtdRequest.get())
+            response.status shouldBe expectedStatus
+            response.json shouldBe Json.toJson(expectedBody)
+            response.header("Content-Type") shouldBe Some("application/json")
+          }
+        }
+
+        def errorBody(code: String): String =
+          s"""
+             |{
+             |   "code": "$code",
+             |   "reason": "downstream message"
+             |}
+            """.stripMargin
+
+        val input = Seq(
+          (BAD_REQUEST, "INVALID_TAXABLE_ENTITY_ID", BAD_REQUEST, NinoFormatError),
+          (BAD_REQUEST, "INVALID_TAX_YEAR", BAD_REQUEST, TaxYearFormatError),
+          (BAD_REQUEST, "INVALID_VIEW", BAD_REQUEST, SourceFormatError),
+          (UNPROCESSABLE_ENTITY, "TAX_YEAR_NOT_SUPPORTED", BAD_REQUEST, RuleTaxYearNotSupportedError),
+          (BAD_REQUEST, "INVALID_CORRELATIONID", INTERNAL_SERVER_ERROR, InternalError),
+          (NOT_FOUND, "NO_DATA_FOUND", NOT_FOUND, NotFoundError),
+          (INTERNAL_SERVER_ERROR, "SERVER_ERROR", INTERNAL_SERVER_ERROR, InternalError),
+          (SERVICE_UNAVAILABLE, "SERVICE_UNAVAILABLE", INTERNAL_SERVER_ERROR, InternalError)
+        )
+        input.foreach(args => (serviceErrorTest).tupled(args))
+      }
+    }
+  }
+
+}

--- a/it/test/v2/endpoints/RetrieveOtherCgtControllerHipISpec.scala
+++ b/it/test/v2/endpoints/RetrieveOtherCgtControllerHipISpec.scala
@@ -1,0 +1,256 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v2.endpoints
+
+import com.github.tomakehurst.wiremock.stubbing.StubMapping
+import play.api.http.HeaderNames.ACCEPT
+import play.api.http.Status.*
+import play.api.libs.json.{JsValue, Json}
+import play.api.libs.ws.{WSRequest, WSResponse}
+import play.api.test.Helpers.AUTHORIZATION
+import shared.models.errors.*
+import shared.services.*
+import shared.support.IntegrationBaseSpec
+
+class RetrieveOtherCgtControllerHipISpec extends IntegrationBaseSpec {
+
+  "Calling the 'retrieve other CGT' endpoint" should {
+    "return a 200 status code" when {
+      "any valid request is made" in new NonTysTest {
+
+        override def setupStubs(): StubMapping = {
+          AuditStub.audit()
+          AuthStub.authorised()
+          MtdIdLookupStub.ninoFound(nino)
+          DownstreamStub.onSuccess(DownstreamStub.GET, downstreamUri, OK, downstreamResponse)
+        }
+
+        val response: WSResponse = await(request.get())
+        response.status shouldBe OK
+        response.json shouldBe mtdResponse
+        response.header("Content-Type") shouldBe Some("application/json")
+      }
+
+      "any valid request with a Tax Year Specific (TYS) tax year is made" in new TysHipTest {
+
+        override def setupStubs(): StubMapping = {
+          AuditStub.audit()
+          AuthStub.authorised()
+          MtdIdLookupStub.ninoFound(nino)
+          DownstreamStub.onSuccess(DownstreamStub.GET, downstreamUri, OK, downstreamResponse)
+        }
+
+        val response: WSResponse = await(request.get())
+        response.status shouldBe OK
+        response.json shouldBe mtdResponse
+        response.header("Content-Type") shouldBe Some("application/json")
+      }
+    }
+
+    "return error according to spec" when {
+      "validation error" when {
+        def validationErrorTest(requestNino: String, requestTaxYear: String, expectedStatus: Int, expectedBody: MtdError): Unit = {
+          s"validation fails with ${expectedBody.code} error" in new NonTysTest {
+
+            override val nino: String    = requestNino
+            override val taxYear: String = requestTaxYear
+
+            override def setupStubs(): StubMapping = {
+              AuditStub.audit()
+              AuthStub.authorised()
+              MtdIdLookupStub.ninoFound(nino)
+            }
+
+            val response: WSResponse = await(request.get())
+            response.status shouldBe expectedStatus
+            response.json shouldBe Json.toJson(expectedBody)
+            response.header("Content-Type") shouldBe Some("application/json")
+          }
+        }
+
+        val input = Seq(
+          ("AA1123A", "2019-20", BAD_REQUEST, NinoFormatError),
+          ("AA123456A", "20177", BAD_REQUEST, TaxYearFormatError),
+          ("AA123456A", "2015-17", BAD_REQUEST, RuleTaxYearRangeInvalidError),
+          ("AA123456A", "2018-19", BAD_REQUEST, RuleTaxYearNotSupportedError),
+          ("AA123456A", "2025-26", BAD_REQUEST, RuleTaxYearForVersionNotSupportedError)
+        )
+        input.foreach(args => (validationErrorTest).tupled(args))
+      }
+
+      "downstream service error" when {
+        def serviceErrorTest(downstreamStatus: Int, downstreamCode: String, expectedStatus: Int, expectedBody: MtdError): Unit = {
+          s"downstream returns an $downstreamCode error and status $downstreamStatus" in new NonTysTest {
+
+            override def setupStubs(): StubMapping = {
+              AuditStub.audit()
+              AuthStub.authorised()
+              MtdIdLookupStub.ninoFound(nino)
+              DownstreamStub.onError(DownstreamStub.GET, downstreamUri, downstreamStatus, errorBody(downstreamCode))
+            }
+
+            val response: WSResponse = await(request.get())
+            response.status shouldBe expectedStatus
+            response.json shouldBe Json.toJson(expectedBody)
+            response.header("Content-Type") shouldBe Some("application/json")
+          }
+        }
+
+        def errorBody(code: String): String =
+          s"""
+             |{
+             |  "origin": "HoD",
+             |  "response": {
+             |    "failures": [
+             |      {
+             |        "type": "$code",
+             |        "reason": "message"
+             |      }
+             |    ]
+             |  }
+             |}
+            """.stripMargin
+
+        val errors = Seq(
+          (BAD_REQUEST, "INVALID_TAXABLE_ENTITY_ID", BAD_REQUEST, NinoFormatError),
+          (BAD_REQUEST, "INVALID_TAX_YEAR", BAD_REQUEST, TaxYearFormatError),
+          (BAD_REQUEST, "INVALID_CORRELATIONID", INTERNAL_SERVER_ERROR, InternalError),
+          (NOT_FOUND, "NO_DATA_FOUND", NOT_FOUND, NotFoundError),
+          (INTERNAL_SERVER_ERROR, "SERVER_ERROR", INTERNAL_SERVER_ERROR, InternalError),
+          (SERVICE_UNAVAILABLE, "SERVICE_UNAVAILABLE", INTERNAL_SERVER_ERROR, InternalError)
+        )
+
+        val extraTysErrors = Seq(
+          (BAD_REQUEST, "INVALID_CORRELATION_ID", INTERNAL_SERVER_ERROR, InternalError),
+          (UNPROCESSABLE_ENTITY, "TAX_YEAR_NOT_SUPPORTED", BAD_REQUEST, RuleTaxYearNotSupportedError)
+        )
+
+        (errors ++ extraTysErrors).foreach(args => (serviceErrorTest).tupled(args))
+      }
+    }
+  }
+
+  private trait Test {
+
+    val nino: String = "AA123456A"
+    def taxYear: String
+    def downstreamUri: String
+
+    val downstreamResponse: JsValue = Json.parse(
+      """
+        |{
+        |   "submittedOn":"2021-05-07T16:18:44.403Z",
+        |   "disposals":[
+        |      {
+        |         "assetType":"otherProperty",
+        |         "assetDescription":"string",
+        |         "acquisitionDate":"2021-05-07",
+        |         "disposalDate":"2021-05-07",
+        |         "disposalProceeds":59999999999.99,
+        |         "allowableCosts":59999999999.99,
+        |         "gain":59999999999.99,
+        |         "claimOrElectionCodes":[
+        |            "OTH"
+        |         ],
+        |         "gainAfterRelief":59999999999.99,
+        |         "rttTaxPaid":59999999999.99
+        |      }
+        |   ],
+        |   "nonStandardGains":{
+        |      "carriedInterestGain":19999999999.99,
+        |      "carriedInterestRttTaxPaid":19999999999.99,
+        |      "attributedGains":19999999999.99,
+        |      "attributedGainsRttTaxPaid":19999999999.99,
+        |      "otherGains":19999999999.99,
+        |      "otherGainsRttTaxPaid":19999999999.99
+        |   },
+        |   "losses":{
+        |      "broughtForwardLossesUsedInCurrentYear":29999999999.99,
+        |      "setAgainstInYearGains":29999999999.99,
+        |      "setAgainstInYearGeneralIncome":29999999999.99,
+        |      "setAgainstEarlierYear":29999999999.99
+        |   },
+        |   "adjustments":-39999999999.99
+        |}
+     """.stripMargin
+    )
+
+    val mtdResponse: JsValue = Json.parse(
+      """
+        |{
+        |   "submittedOn":"2021-05-07T16:18:44.403Z",
+        |   "disposals":[
+        |      {
+        |         "assetType":"other-property",
+        |         "assetDescription":"string",
+        |         "acquisitionDate":"2021-05-07",
+        |         "disposalDate":"2021-05-07",
+        |         "disposalProceeds":59999999999.99,
+        |         "allowableCosts":59999999999.99,
+        |         "gain":59999999999.99,
+        |         "claimOrElectionCodes":[
+        |            "OTH"
+        |         ],
+        |         "gainAfterRelief":59999999999.99,
+        |         "rttTaxPaid":59999999999.99
+        |      }
+        |   ],
+        |   "nonStandardGains":{
+        |      "carriedInterestGain":19999999999.99,
+        |      "carriedInterestRttTaxPaid":19999999999.99,
+        |      "attributedGains":19999999999.99,
+        |      "attributedGainsRttTaxPaid":19999999999.99,
+        |      "otherGains":19999999999.99,
+        |      "otherGainsRttTaxPaid":19999999999.99
+        |   },
+        |   "losses":{
+        |      "broughtForwardLossesUsedInCurrentYear":29999999999.99,
+        |      "setAgainstInYearGains":29999999999.99,
+        |      "setAgainstInYearGeneralIncome":29999999999.99,
+        |      "setAgainstEarlierYear":29999999999.99
+        |   },
+        |   "adjustments":-39999999999.99
+        |}
+     """.stripMargin
+    )
+
+    def uri: String = s"/other-gains/$nino/$taxYear"
+
+    def setupStubs(): StubMapping
+
+    def request: WSRequest = {
+      setupStubs()
+      buildRequest(uri)
+        .withHttpHeaders(
+          (ACCEPT, "application/vnd.hmrc.2.0+json"),
+          (AUTHORIZATION, "Bearer 123") // some bearer token
+        )
+    }
+
+  }
+
+  private trait NonTysTest extends Test {
+    def taxYear: String       = "2019-20"
+    def downstreamUri: String = s"/income-tax/income/disposals/other-gains/$nino/2019-20"
+  }
+
+  private trait TysHipTest extends Test {
+    def taxYear: String       = "2024-25"
+    def downstreamUri: String = s"/itsa/income-tax/v1/24-25/income/disposals/other-gains/$nino"
+  }
+
+}

--- a/it/test/v2/endpoints/RetrieveOtherCgtControllerIfsISpec.scala
+++ b/it/test/v2/endpoints/RetrieveOtherCgtControllerIfsISpec.scala
@@ -1,0 +1,252 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v2.endpoints
+
+import com.github.tomakehurst.wiremock.stubbing.StubMapping
+import play.api.http.HeaderNames.ACCEPT
+import play.api.http.Status.*
+import play.api.libs.json.{JsValue, Json}
+import play.api.libs.ws.{WSRequest, WSResponse}
+import play.api.test.Helpers.AUTHORIZATION
+import shared.models.errors.*
+import shared.services.*
+import shared.support.IntegrationBaseSpec
+
+class RetrieveOtherCgtControllerIfsISpec extends IntegrationBaseSpec {
+
+  override def servicesConfig: Map[String, Any] =
+    Map("feature-switch.ifs_hip_migration_1951.enabled" -> false) ++ super.servicesConfig
+
+  "Calling the 'retrieve other CGT' endpoint" should {
+    "return a 200 status code" when {
+      "any valid request is made" in new NonTysTest {
+
+        override def setupStubs(): StubMapping = {
+          AuditStub.audit()
+          AuthStub.authorised()
+          MtdIdLookupStub.ninoFound(nino)
+          DownstreamStub.onSuccess(DownstreamStub.GET, downstreamUri, OK, downstreamResponse)
+        }
+
+        val response: WSResponse = await(request.get())
+        response.status shouldBe OK
+        response.json shouldBe mtdResponse
+        response.header("Content-Type") shouldBe Some("application/json")
+      }
+
+      "any valid request with a Tax Year Specific (TYS) tax year is made" in new TysIfsTest {
+
+        override def setupStubs(): StubMapping = {
+          AuditStub.audit()
+          AuthStub.authorised()
+          MtdIdLookupStub.ninoFound(nino)
+          DownstreamStub.onSuccess(DownstreamStub.GET, downstreamUri, OK, downstreamResponse)
+        }
+
+        val response: WSResponse = await(request.get())
+        response.status shouldBe OK
+        response.json shouldBe mtdResponse
+        response.header("Content-Type") shouldBe Some("application/json")
+      }
+    }
+
+    "return error according to spec" when {
+      "validation error" when {
+        def validationErrorTest(requestNino: String, requestTaxYear: String, expectedStatus: Int, expectedBody: MtdError): Unit = {
+          s"validation fails with ${expectedBody.code} error" in new NonTysTest {
+
+            override val nino: String    = requestNino
+            override val taxYear: String = requestTaxYear
+
+            override def setupStubs(): StubMapping = {
+              AuditStub.audit()
+              AuthStub.authorised()
+              MtdIdLookupStub.ninoFound(nino)
+            }
+
+            val response: WSResponse = await(request.get())
+            response.status shouldBe expectedStatus
+            response.json shouldBe Json.toJson(expectedBody)
+            response.header("Content-Type") shouldBe Some("application/json")
+          }
+        }
+
+        val input = Seq(
+          ("AA1123A", "2019-20", BAD_REQUEST, NinoFormatError),
+          ("AA123456A", "20177", BAD_REQUEST, TaxYearFormatError),
+          ("AA123456A", "2015-17", BAD_REQUEST, RuleTaxYearRangeInvalidError),
+          ("AA123456A", "2018-19", BAD_REQUEST, RuleTaxYearNotSupportedError),
+          ("AA123456A", "2025-26", BAD_REQUEST, RuleTaxYearForVersionNotSupportedError)
+        )
+        input.foreach(args => (validationErrorTest).tupled(args))
+      }
+
+      "downstream service error" when {
+        def serviceErrorTest(downstreamStatus: Int, downstreamCode: String, expectedStatus: Int, expectedBody: MtdError): Unit = {
+          s"downstream returns an $downstreamCode error and status $downstreamStatus" in new NonTysTest {
+
+            override def setupStubs(): StubMapping = {
+              AuditStub.audit()
+              AuthStub.authorised()
+              MtdIdLookupStub.ninoFound(nino)
+              DownstreamStub.onError(DownstreamStub.GET, downstreamUri, downstreamStatus, errorBody(downstreamCode))
+            }
+
+            val response: WSResponse = await(request.get())
+            response.status shouldBe expectedStatus
+            response.json shouldBe Json.toJson(expectedBody)
+            response.header("Content-Type") shouldBe Some("application/json")
+          }
+        }
+
+        def errorBody(code: String): String =
+          s"""
+             |{
+             |   "code": "$code",
+             |   "reason": "downstream message"
+             |}
+            """.stripMargin
+
+        val errors = Seq(
+          (BAD_REQUEST, "INVALID_TAXABLE_ENTITY_ID", BAD_REQUEST, NinoFormatError),
+          (BAD_REQUEST, "INVALID_TAX_YEAR", BAD_REQUEST, TaxYearFormatError),
+          (BAD_REQUEST, "INVALID_CORRELATIONID", INTERNAL_SERVER_ERROR, InternalError),
+          (NOT_FOUND, "NO_DATA_FOUND", NOT_FOUND, NotFoundError),
+          (INTERNAL_SERVER_ERROR, "SERVER_ERROR", INTERNAL_SERVER_ERROR, InternalError),
+          (SERVICE_UNAVAILABLE, "SERVICE_UNAVAILABLE", INTERNAL_SERVER_ERROR, InternalError)
+        )
+
+        val extraTysErrors = Seq(
+          (BAD_REQUEST, "INVALID_CORRELATION_ID", INTERNAL_SERVER_ERROR, InternalError),
+          (UNPROCESSABLE_ENTITY, "TAX_YEAR_NOT_SUPPORTED", BAD_REQUEST, RuleTaxYearNotSupportedError)
+        )
+
+        (errors ++ extraTysErrors).foreach(args => (serviceErrorTest).tupled(args))
+      }
+    }
+  }
+
+  private trait Test {
+
+    val nino: String = "AA123456A"
+    def taxYear: String
+    def downstreamUri: String
+
+    val downstreamResponse: JsValue = Json.parse(
+      """
+        |{
+        |   "submittedOn":"2021-05-07T16:18:44.403Z",
+        |   "disposals":[
+        |      {
+        |         "assetType":"otherProperty",
+        |         "assetDescription":"string",
+        |         "acquisitionDate":"2021-05-07",
+        |         "disposalDate":"2021-05-07",
+        |         "disposalProceeds":59999999999.99,
+        |         "allowableCosts":59999999999.99,
+        |         "gain":59999999999.99,
+        |         "claimOrElectionCodes":[
+        |            "OTH"
+        |         ],
+        |         "gainAfterRelief":59999999999.99,
+        |         "rttTaxPaid":59999999999.99
+        |      }
+        |   ],
+        |   "nonStandardGains":{
+        |      "carriedInterestGain":19999999999.99,
+        |      "carriedInterestRttTaxPaid":19999999999.99,
+        |      "attributedGains":19999999999.99,
+        |      "attributedGainsRttTaxPaid":19999999999.99,
+        |      "otherGains":19999999999.99,
+        |      "otherGainsRttTaxPaid":19999999999.99
+        |   },
+        |   "losses":{
+        |      "broughtForwardLossesUsedInCurrentYear":29999999999.99,
+        |      "setAgainstInYearGains":29999999999.99,
+        |      "setAgainstInYearGeneralIncome":29999999999.99,
+        |      "setAgainstEarlierYear":29999999999.99
+        |   },
+        |   "adjustments":-39999999999.99
+        |}
+     """.stripMargin
+    )
+
+    val mtdResponse: JsValue = Json.parse(
+      """
+        |{
+        |   "submittedOn":"2021-05-07T16:18:44.403Z",
+        |   "disposals":[
+        |      {
+        |         "assetType":"other-property",
+        |         "assetDescription":"string",
+        |         "acquisitionDate":"2021-05-07",
+        |         "disposalDate":"2021-05-07",
+        |         "disposalProceeds":59999999999.99,
+        |         "allowableCosts":59999999999.99,
+        |         "gain":59999999999.99,
+        |         "claimOrElectionCodes":[
+        |            "OTH"
+        |         ],
+        |         "gainAfterRelief":59999999999.99,
+        |         "rttTaxPaid":59999999999.99
+        |      }
+        |   ],
+        |   "nonStandardGains":{
+        |      "carriedInterestGain":19999999999.99,
+        |      "carriedInterestRttTaxPaid":19999999999.99,
+        |      "attributedGains":19999999999.99,
+        |      "attributedGainsRttTaxPaid":19999999999.99,
+        |      "otherGains":19999999999.99,
+        |      "otherGainsRttTaxPaid":19999999999.99
+        |   },
+        |   "losses":{
+        |      "broughtForwardLossesUsedInCurrentYear":29999999999.99,
+        |      "setAgainstInYearGains":29999999999.99,
+        |      "setAgainstInYearGeneralIncome":29999999999.99,
+        |      "setAgainstEarlierYear":29999999999.99
+        |   },
+        |   "adjustments":-39999999999.99
+        |}
+     """.stripMargin
+    )
+
+    def uri: String = s"/other-gains/$nino/$taxYear"
+
+    def setupStubs(): StubMapping
+
+    def request: WSRequest = {
+      setupStubs()
+      buildRequest(uri)
+        .withHttpHeaders(
+          (ACCEPT, "application/vnd.hmrc.2.0+json"),
+          (AUTHORIZATION, "Bearer 123") // some bearer token
+        )
+    }
+
+  }
+
+  private trait NonTysTest extends Test {
+    def taxYear: String       = "2019-20"
+    def downstreamUri: String = s"/income-tax/income/disposals/other-gains/$nino/2019-20"
+  }
+
+  private trait TysIfsTest extends Test {
+    def taxYear: String       = "2023-24"
+    def downstreamUri: String = s"/income-tax/income/disposals/other-gains/23-24/$nino"
+  }
+
+}

--- a/resources/public/api/conf/1.0/all_cgt_residential_overrides_retrieve.yaml
+++ b/resources/public/api/conf/1.0/all_cgt_residential_overrides_retrieve.yaml
@@ -69,6 +69,8 @@ responses:
             $ref: './common/errors.yaml#/components/examples/formatSource'
           RULE_TAX_YEAR_NOT_SUPPORTED:
             $ref: './common/errors.yaml#/components/examples/ruleTaxYearNotSupported'
+          RULE_TAX_YEAR_FOR_VERSION_NOT_SUPPORTED:
+            $ref: './common/errors.yaml#/components/examples/ruleTaxYearForVersionNotSupported'
           RULE_TAX_YEAR_RANGE_INVALID:
             $ref: './common/errors.yaml#/components/examples/ruleTaxYearRangeInvalid'
           RULE_INCORRECT_GOV_TEST_SCENARIO:

--- a/resources/public/api/conf/1.0/capital_gains_other_create_amend.yaml
+++ b/resources/public/api/conf/1.0/capital_gains_other_create_amend.yaml
@@ -75,6 +75,8 @@ responses:
             $ref: './common/errors.yaml#/components/examples/ruleTaxYearRangeInvalid'
           RULE_TAX_YEAR_NOT_SUPPORTED:
             $ref: './common/errors.yaml#/components/examples/ruleTaxYearNotSupported'
+          RULE_TAX_YEAR_FOR_VERSION_NOT_SUPPORTED:
+            $ref: './common/errors.yaml#/components/examples/ruleTaxYearForVersionNotSupported'
           RULE_INCORRECT_OR_EMPTY_BODY_SUBMITTED:
             $ref: './common/errors.yaml#/components/examples/ruleIncorrectOrEmptyBody'
           RULE_DISPOSAL_DATE_NOT_FUTURE:

--- a/resources/public/api/conf/1.0/capital_gains_other_delete.yaml
+++ b/resources/public/api/conf/1.0/capital_gains_other_delete.yaml
@@ -53,6 +53,8 @@ responses:
             $ref: './common/errors.yaml#/components/examples/ruleTaxYearRangeInvalid'
           RULE_TAX_YEAR_NOT_SUPPORTED:
             $ref: './common/errors.yaml#/components/examples/ruleTaxYearNotSupported'
+          RULE_TAX_YEAR_FOR_VERSION_NOT_SUPPORTED:
+            $ref: "./common/errors.yaml#/components/examples/ruleTaxYearForVersionNotSupported"
           RULE_INCORRECT_GOV_TEST_SCENARIO:
             $ref: './common/errors.yaml#/components/examples/ruleIncorrectGovTestScenario'
 

--- a/resources/public/api/conf/1.0/capital_gains_other_retrieve.yaml
+++ b/resources/public/api/conf/1.0/capital_gains_other_retrieve.yaml
@@ -63,6 +63,8 @@ responses:
             $ref: './common/errors.yaml#/components/examples/ruleTaxYearRangeInvalid'
           RULE_TAX_YEAR_NOT_SUPPORTED:
             $ref: './common/errors.yaml#/components/examples/ruleTaxYearNotSupported'
+          RULE_TAX_YEAR_FOR_VERSION_NOT_SUPPORTED:
+            $ref: './common/errors.yaml#/components/examples/ruleTaxYearForVersionNotSupported'
           RULE_INCORRECT_GOV_TEST_SCENARIO:
             $ref: './common/errors.yaml#/components/examples/ruleIncorrectGovTestScenario'
 

--- a/resources/public/api/conf/1.0/cgt_residential_overrides_ppd_create_amend.yaml
+++ b/resources/public/api/conf/1.0/cgt_residential_overrides_ppd_create_amend.yaml
@@ -80,6 +80,8 @@ responses:
             $ref: './common/errors.yaml#/components/examples/ruleAmountGainLoss'
           RULE_TAX_YEAR_NOT_ENDED:
             $ref: './common/errors.yaml#/components/examples/ruleTaxYearNotEnded'
+          RULE_TAX_YEAR_FOR_VERSION_NOT_SUPPORTED:
+            $ref: './common/errors.yaml#/components/examples/ruleTaxYearForVersionNotSupported'
           RULE_INCORRECT_OR_EMPTY_BODY_SUBMITTED:
             $ref: './common/errors.yaml#/components/examples/ruleIncorrectOrEmptyBody'
           RULE_DUPLICATED_PPD_SUBMISSION_ID:

--- a/resources/public/api/conf/1.0/cgt_residential_overrides_ppd_delete.yaml
+++ b/resources/public/api/conf/1.0/cgt_residential_overrides_ppd_delete.yaml
@@ -50,6 +50,8 @@ responses:
             $ref: './common/errors.yaml#/components/examples/formatTaxYear'
           RULE_TAX_YEAR_NOT_SUPPORTED:
             $ref: './common/errors.yaml#/components/examples/ruleTaxYearNotSupported'
+          RULE_TAX_YEAR_FOR_VERSION_NOT_SUPPORTED:
+            $ref: './common/errors.yaml#/components/examples/ruleTaxYearForVersionNotSupported'
           RULE_TAX_YEAR_RANGE_INVALID:
             $ref: './common/errors.yaml#/components/examples/ruleTaxYearRangeInvalid'
           RULE_INCORRECT_GOV_TEST_SCENARIO:

--- a/resources/public/api/conf/2.0/all_cgt_residential_overrides_retrieve.yaml
+++ b/resources/public/api/conf/2.0/all_cgt_residential_overrides_retrieve.yaml
@@ -69,6 +69,8 @@ responses:
             $ref: './common/errors.yaml#/components/examples/formatSource'
           RULE_TAX_YEAR_NOT_SUPPORTED:
             $ref: './common/errors.yaml#/components/examples/ruleTaxYearNotSupported'
+          RULE_TAX_YEAR_FOR_VERSION_NOT_SUPPORTED:
+            $ref: './common/errors.yaml#/components/examples/ruleTaxYearForVersionNotSupported'
           RULE_TAX_YEAR_RANGE_INVALID:
             $ref: './common/errors.yaml#/components/examples/ruleTaxYearRangeInvalid'
           RULE_INCORRECT_GOV_TEST_SCENARIO:

--- a/resources/public/api/conf/2.0/capital_gains_other_create_amend.yaml
+++ b/resources/public/api/conf/2.0/capital_gains_other_create_amend.yaml
@@ -76,6 +76,8 @@ responses:
             $ref: './common/errors.yaml#/components/examples/ruleTaxYearRangeInvalid'
           RULE_TAX_YEAR_NOT_SUPPORTED:
             $ref: './common/errors.yaml#/components/examples/ruleTaxYearNotSupported'
+          RULE_TAX_YEAR_FOR_VERSION_NOT_SUPPORTED:
+            $ref: './common/errors.yaml#/components/examples/ruleTaxYearForVersionNotSupported'
           RULE_INCORRECT_OR_EMPTY_BODY_SUBMITTED:
             $ref: './common/errors.yaml#/components/examples/ruleIncorrectOrEmptyBody'
           RULE_DISPOSAL_DATE_NOT_FUTURE:

--- a/resources/public/api/conf/2.0/capital_gains_other_delete.yaml
+++ b/resources/public/api/conf/2.0/capital_gains_other_delete.yaml
@@ -54,6 +54,8 @@ responses:
             $ref: './common/errors.yaml#/components/examples/ruleTaxYearRangeInvalid'
           RULE_TAX_YEAR_NOT_SUPPORTED:
             $ref: './common/errors.yaml#/components/examples/ruleTaxYearNotSupported'
+          RULE_TAX_YEAR_FOR_VERSION_NOT_SUPPORTED:
+            $ref: "./common/errors.yaml#/components/examples/ruleTaxYearForVersionNotSupported"
           RULE_INCORRECT_GOV_TEST_SCENARIO:
             $ref: './common/errors.yaml#/components/examples/ruleIncorrectGovTestScenario'
           RULE_OUTSIDE_AMENDMENT_WINDOW:

--- a/resources/public/api/conf/2.0/capital_gains_other_retrieve.yaml
+++ b/resources/public/api/conf/2.0/capital_gains_other_retrieve.yaml
@@ -63,6 +63,8 @@ responses:
             $ref: './common/errors.yaml#/components/examples/ruleTaxYearRangeInvalid'
           RULE_TAX_YEAR_NOT_SUPPORTED:
             $ref: './common/errors.yaml#/components/examples/ruleTaxYearNotSupported'
+          RULE_TAX_YEAR_FOR_VERSION_NOT_SUPPORTED:
+            $ref: './common/errors.yaml#/components/examples/ruleTaxYearForVersionNotSupported'
           RULE_INCORRECT_GOV_TEST_SCENARIO:
             $ref: './common/errors.yaml#/components/examples/ruleIncorrectGovTestScenario'
 

--- a/resources/public/api/conf/2.0/cgt_residential_overrides_ppd_create_amend.yaml
+++ b/resources/public/api/conf/2.0/cgt_residential_overrides_ppd_create_amend.yaml
@@ -75,6 +75,8 @@ responses:
             $ref: './common/errors.yaml#/components/examples/formatPpdSubmissionId'
           RULE_TAX_YEAR_NOT_SUPPORTED:
             $ref: './common/errors.yaml#/components/examples/ruleTaxYearNotSupported'
+          RULE_TAX_YEAR_FOR_VERSION_NOT_SUPPORTED:
+            $ref: './common/errors.yaml#/components/examples/ruleTaxYearForVersionNotSupported'
           RULE_TAX_YEAR_RANGE_INVALID:
             $ref: './common/errors.yaml#/components/examples/ruleTaxYearRangeInvalid'
           RULE_AMOUNT_GAIN_LOSS:

--- a/resources/public/api/conf/2.0/cgt_residential_overrides_ppd_delete.yaml
+++ b/resources/public/api/conf/2.0/cgt_residential_overrides_ppd_delete.yaml
@@ -51,6 +51,8 @@ responses:
             $ref: './common/errors.yaml#/components/examples/formatTaxYear'
           RULE_TAX_YEAR_NOT_SUPPORTED:
             $ref: './common/errors.yaml#/components/examples/ruleTaxYearNotSupported'
+          RULE_TAX_YEAR_FOR_VERSION_NOT_SUPPORTED:
+            $ref: './common/errors.yaml#/components/examples/ruleTaxYearForVersionNotSupported'
           RULE_TAX_YEAR_RANGE_INVALID:
             $ref: './common/errors.yaml#/components/examples/ruleTaxYearRangeInvalid'
           RULE_INCORRECT_GOV_TEST_SCENARIO:

--- a/test/v1/otherCgt/createAmend/CreateAmendOtherCgtConnectorSpec.scala
+++ b/test/v1/otherCgt/createAmend/CreateAmendOtherCgtConnectorSpec.scala
@@ -17,6 +17,7 @@
 package v1.otherCgt.createAmend
 
 import config.MockAppConfig
+import play.api.Configuration
 import shared.connectors.ConnectorSpec
 import shared.models.domain.{Nino, TaxYear}
 import shared.models.outcomes.ResponseWrapper
@@ -40,8 +41,9 @@ class CreateAmendOtherCgtConnectorSpec extends ConnectorSpec with MockAppConfig 
     "X-Session-Id"
   )
 
-  trait Test { self: ConnectorTest =>
-    def taxYear: TaxYear
+  trait Test {
+    self: ConnectorTest =>
+    def taxYear: TaxYear = TaxYear.fromMtd("2023-24")
 
     val connector: CreateAmendOtherCgtConnector = new CreateAmendOtherCgtConnector(
       http = mockHttpClient,
@@ -50,19 +52,22 @@ class CreateAmendOtherCgtConnectorSpec extends ConnectorSpec with MockAppConfig 
 
   }
 
-  "createAndAmend" should {
-    "return a 204 status" when {
+  "createAndAmendOtherCgtConnector" should {
+    "return the expected response for a non-TYS IFS request" when {
       "a valid request is made" in new IfsTest with Test {
+        MockedSharedAppConfig.featureSwitchConfig returns Configuration("ifs_hip_migration_1886.enabled" -> false)
 
         override val taxYear: TaxYear = TaxYear.fromMtd("2019-20")
 
-        val createAmendOtherCgtRequestData: CreateAmendOtherCgtRequestData = Def1_CreateAmendOtherCgtRequestData(
-          nino = Nino(nino),
-          taxYear = taxYear,
-          body = mtdRequestBody
-        )
+        val createAmendOtherCgtRequestData: CreateAmendOtherCgtRequestData =
+          Def1_CreateAmendOtherCgtRequestData(
+            nino = Nino(nino),
+            taxYear = taxYear,
+            body = mtdRequestBody
+          )
 
-        val outcome: Right[Nothing, ResponseWrapper[Unit]] = Right(ResponseWrapper(correlationId, ()))
+        val outcome: Right[Nothing, ResponseWrapper[Unit]] =
+          Right(ResponseWrapper(correlationId, ()))
 
         willPut(
           url = url"$baseUrl/income-tax/income/disposals/other-gains/$nino/2019-20",
@@ -71,19 +76,47 @@ class CreateAmendOtherCgtConnectorSpec extends ConnectorSpec with MockAppConfig 
 
         await(connector.createAndAmend(createAmendOtherCgtRequestData)) shouldBe outcome
       }
+    }
 
-      "a valid request is made with Tax Year Specific tax year" in new IfsTest with Test {
+    "return the expected response for a TYS IFS request" when {
+      "a valid request is made" in new IfsTest with Test {
+        MockedSharedAppConfig.featureSwitchConfig returns Configuration("ifs_hip_migration_1886.enabled" -> false)
 
         override val taxYear: TaxYear = TaxYear.fromMtd("2023-24")
+
+        val createAmendOtherCgtRequestData: CreateAmendOtherCgtRequestData =
+          Def1_CreateAmendOtherCgtRequestData(
+            nino = Nino(nino),
+            taxYear = taxYear,
+            body = mtdRequestBody
+          )
+
+        val outcome: Right[Nothing, ResponseWrapper[Unit]] =
+          Right(ResponseWrapper(correlationId, ()))
+
+        willPut(
+          url = url"$baseUrl/income-tax/income/disposals/other-gains/23-24/$nino",
+          body = mtdRequestBody
+        ).returns(Future.successful(outcome))
+
+        await(connector.createAndAmend(createAmendOtherCgtRequestData)) shouldBe outcome
+      }
+    }
+
+    "return the expected response for a HIP request" when {
+      "a valid request is made" in new HipTest with Test {
+        MockedSharedAppConfig.featureSwitchConfig returns Configuration("ifs_hip_migration_1886.enabled" -> true)
+
         val createAmendOtherCgtRequestData: CreateAmendOtherCgtRequestData = Def1_CreateAmendOtherCgtRequestData(
           nino = Nino(nino),
           taxYear = taxYear,
           body = mtdRequestBody
         )
-        val outcome: Right[Nothing, ResponseWrapper[Unit]] = Right(ResponseWrapper(correlationId, ()))
+
+        val outcome = Right(ResponseWrapper(correlationId, ()))
 
         willPut(
-          url = url"$baseUrl/income-tax/income/disposals/other-gains/23-24/$nino",
+          url = url"$baseUrl/itsa/income-tax/v1/23-24/income/disposals/other-gains/$nino",
           body = mtdRequestBody
         ).returns(Future.successful(outcome))
 

--- a/test/v1/otherCgt/createAmend/def1/Def1_CreateAmendOtherCgtRulesValidatorSpec.scala
+++ b/test/v1/otherCgt/createAmend/def1/Def1_CreateAmendOtherCgtRulesValidatorSpec.scala
@@ -154,8 +154,14 @@ class Def1_CreateAmendOtherCgtRulesValidatorSpec extends UnitSpec with MockAppCo
     }
 
     "return RuleTaxYearNotSupportedError error" when {
-      "an out of range tax year is supplied" in new Test {
-        validate(taxYear = "2016-17") shouldBe error(RuleTaxYearNotSupportedError)
+      "a tax year after the minimum tax year is supplied" in new Test {
+        validate(taxYear = "2019-20") shouldBe error(RuleTaxYearNotSupportedError)
+      }
+    }
+
+    "return RuleTaxYearForVersionNotSupportedError error" when {
+      "a tax year after the maximum tax year is supplied" in new Test {
+        validate(taxYear = "2025-26") shouldBe error(RuleTaxYearForVersionNotSupportedError)
       }
     }
 

--- a/test/v1/otherCgt/delete/def1/Def1_DeleteOtherCgtValidatorSpec.scala
+++ b/test/v1/otherCgt/delete/def1/Def1_DeleteOtherCgtValidatorSpec.scala
@@ -88,6 +88,15 @@ class Def1_DeleteOtherCgtValidatorSpec extends UnitSpec with MockAppConfig {
       }
     }
 
+    "return RuleTaxYearForVersionNotSupportedError error" when {
+      "a tax year that is not supported by this version is supplied" in new Test {
+        val result: Either[ErrorWrapper, DeleteOtherCgtRequestData] =
+          validator(validNino, "2025-26")
+
+        result shouldBe Left(ErrorWrapper(correlationId, RuleTaxYearForVersionNotSupportedError))
+      }
+    }
+
     "return multiple errors" when {
       "request supplied has multiple errors" in new Test {
         val result: Either[ErrorWrapper, DeleteOtherCgtRequestData] =

--- a/test/v1/otherCgt/retrieve/RetrieveOtherCgtConnectorSpec.scala
+++ b/test/v1/otherCgt/retrieve/RetrieveOtherCgtConnectorSpec.scala
@@ -17,7 +17,9 @@
 package v1.otherCgt.retrieve
 
 import common.connectors.CgtConnectorSpec
+import play.api.Configuration
 import shared.models.domain.{Nino, TaxYear, Timestamp}
+import shared.models.errors.NinoFormatError
 import shared.models.outcomes.ResponseWrapper
 import uk.gov.hmrc.http.StringContextOps
 import v1.otherCgt.retrieve.def1.model.request.Def1_RetrieveOtherCgtRequestData
@@ -32,8 +34,9 @@ class RetrieveOtherCgtConnectorSpec extends CgtConnectorSpec {
   "RetrieveOtherCgtConnector" should {
     "return the expected response for a non-TYS request" when {
       "a valid request is made" in new Api1661Test with Test {
-        def taxYear: TaxYear = TaxYear.fromMtd("2019-20")
-        val outcome          = Right(ResponseWrapper(correlationId, response))
+        override def taxYear: TaxYear = TaxYear.fromMtd("2019-20")
+
+        val outcome: Right[Nothing, ResponseWrapper[RetrieveOtherCgtResponse]] = Right(ResponseWrapper(correlationId, response))
 
         willGet(
           url = url"$baseUrl/income-tax/income/disposals/other-gains/$nino/2019-20"
@@ -42,13 +45,39 @@ class RetrieveOtherCgtConnectorSpec extends CgtConnectorSpec {
         await(connector.retrieveOtherCgt(request)) shouldBe outcome
       }
     }
+
     "return the expected response for a TYS request" when {
       "a valid request is made" in new IfsTest with Test {
-        def taxYear: TaxYear = TaxYear.fromMtd("2023-24")
-        val outcome          = Right(ResponseWrapper(correlationId, response))
+        MockedSharedAppConfig.featureSwitchConfig.returns(Configuration("ifs_hip_migration_1951.enabled" -> false))
+        val outcome: Right[Nothing, ResponseWrapper[RetrieveOtherCgtResponse]] = Right(ResponseWrapper(correlationId, response))
 
         willGet(
           url = url"$baseUrl/income-tax/income/disposals/other-gains/23-24/$nino"
+        ).returns(Future.successful(outcome))
+
+        await(connector.retrieveOtherCgt(request)) shouldBe outcome
+      }
+    }
+
+    "return a success response when feature switch is enabled (HIP enabled)" in new HipTest with Test {
+      MockedSharedAppConfig.featureSwitchConfig.returns(Configuration("ifs_hip_migration_1951.enabled" -> true))
+      val outcome: Right[Nothing, ResponseWrapper[RetrieveOtherCgtResponse]] = Right(ResponseWrapper(correlationId, response))
+
+      willGet(
+        url = url"$baseUrl/itsa/income-tax/v1/${taxYear.asTysDownstream}/income/disposals/other-gains/$nino"
+      ).returns(Future.successful(outcome))
+
+      await(connector.retrieveOtherCgt(request)) shouldBe outcome
+    }
+
+    "given a request returning an error" must {
+      "return an unsuccessful response with the correct correlationId and a single error" in new HipTest with Test {
+        MockedSharedAppConfig.featureSwitchConfig.returns(Configuration("ifs_hip_migration_1951.enabled" -> true))
+
+        val outcome: Left[ResponseWrapper[NinoFormatError.type], Nothing] = Left(ResponseWrapper(correlationId, NinoFormatError))
+
+        willGet(
+          url = url"$baseUrl/itsa/income-tax/v1/${taxYear.asTysDownstream}/income/disposals/other-gains/$nino"
         ).returns(Future.successful(outcome))
 
         await(connector.retrieveOtherCgt(request)) shouldBe outcome
@@ -59,7 +88,7 @@ class RetrieveOtherCgtConnectorSpec extends CgtConnectorSpec {
   trait Test {
     self: ConnectorTest =>
 
-    def taxYear: TaxYear
+    def taxYear: TaxYear = TaxYear.fromMtd("2023-24")
 
     protected val nino: String = "AA111111A"
 

--- a/test/v1/otherCgt/retrieve/def1/Def1_RetrieveOtherCgtValidatorSpec.scala
+++ b/test/v1/otherCgt/retrieve/def1/Def1_RetrieveOtherCgtValidatorSpec.scala
@@ -21,6 +21,7 @@ import shared.models.domain.{Nino, TaxYear}
 import shared.models.errors.*
 import support.UnitSpec
 import v1.otherCgt.retrieve.def1.model.request.Def1_RetrieveOtherCgtRequestData
+import v1.otherCgt.retrieve.model.request.RetrieveOtherCgtRequestData
 
 class Def1_RetrieveOtherCgtValidatorSpec extends UnitSpec with MockAppConfig {
 
@@ -45,50 +46,55 @@ class Def1_RetrieveOtherCgtValidatorSpec extends UnitSpec with MockAppConfig {
   "validator" should {
     "return the parsed domain object" when {
       "a valid request is supplied" in new Test {
-        val result = validator(validNino, validTaxYear)
+        val result: Either[ErrorWrapper, RetrieveOtherCgtRequestData] = validator(validNino, validTaxYear)
+
         result shouldBe Right(Def1_RetrieveOtherCgtRequestData(parsedNino, parsedTaxYear))
       }
     }
 
     "return NinoFormatError error" when {
       "an invalid nino is supplied" in new Test {
-        val result = validator("A12344A", validTaxYear)
-        result shouldBe Left(
-          ErrorWrapper(correlationId, NinoFormatError)
-        )
+        val result: Either[ErrorWrapper, RetrieveOtherCgtRequestData] = validator("A12344A", validTaxYear)
+
+        result shouldBe Left(ErrorWrapper(correlationId, NinoFormatError))
       }
     }
 
     "return TaxYearFormatError error" when {
       "an invalid tax year is supplied" in new Test {
-        val result = validator(validNino, "201718")
-        result shouldBe Left(
-          ErrorWrapper(correlationId, TaxYearFormatError)
-        )
+        val result: Either[ErrorWrapper, RetrieveOtherCgtRequestData] = validator(validNino, "201718")
+
+        result shouldBe Left(ErrorWrapper(correlationId, TaxYearFormatError))
       }
     }
 
     "return RuleTaxYearNotSupportedError error" when {
-      "an out of range tax year is supplied" in new Test {
-        val result = validator(validNino, "2016-17")
-        result shouldBe Left(
-          ErrorWrapper(correlationId, RuleTaxYearNotSupportedError)
-        )
+      "a tax year before the minimum tax year is supplied" in new Test {
+        val result: Either[ErrorWrapper, RetrieveOtherCgtRequestData] = validator(validNino, "2016-17")
+
+        result shouldBe Left(ErrorWrapper(correlationId, RuleTaxYearNotSupportedError))
+      }
+    }
+
+    "return RuleTaxYearForVersionNotSupportedError error" when {
+      "a tax year after the maximum tax year is supplied" in new Test {
+        val result: Either[ErrorWrapper, RetrieveOtherCgtRequestData] = validator(validNino, "2025-26")
+
+        result shouldBe Left(ErrorWrapper(correlationId, RuleTaxYearForVersionNotSupportedError))
       }
     }
 
     "return RuleTaxYearRangeInvalidError error" when {
       "an invalid tax year range is supplied" in new Test {
-        val result = validator(validNino, "2017-19")
-        result shouldBe Left(
-          ErrorWrapper(correlationId, RuleTaxYearRangeInvalidError)
-        )
+        val result: Either[ErrorWrapper, RetrieveOtherCgtRequestData] = validator(validNino, "2017-19")
+
+        result shouldBe Left(ErrorWrapper(correlationId, RuleTaxYearRangeInvalidError))
       }
     }
 
     "return multiple errors" when {
       "multiple invalid parameters are provided" in new Test {
-        val result = validator("not-a-nino", "2017-19")
+        val result: Either[ErrorWrapper, RetrieveOtherCgtRequestData] = validator("not-a-nino", "2017-19")
 
         result shouldBe Left(
           ErrorWrapper(

--- a/test/v1/residentialPropertyDisposals/createAmendCgtPpdOverrides/CreateAmendCgtPpdOverridesValidatorFactorySpec.scala
+++ b/test/v1/residentialPropertyDisposals/createAmendCgtPpdOverrides/CreateAmendCgtPpdOverridesValidatorFactorySpec.scala
@@ -25,7 +25,7 @@ import v1.residentialPropertyDisposals.createAmendCgtPpdOverrides.def1.Def1_Crea
 class CreateAmendCgtPpdOverridesValidatorFactorySpec extends UnitSpec with JsonErrorValidators with MockAppConfig {
 
   private val validNino    = "AA123456A"
-  private val validTaxYear = "2021-22"
+  private val validTaxYear = "2019-20"
 
   def requestBodyJson(): JsValue = Json.parse(
     s"""

--- a/test/v1/residentialPropertyDisposals/createAmendCgtPpdOverrides/def1/Def1_CreateAmendCgtPpdOverridesRulesValidatorSpec.scala
+++ b/test/v1/residentialPropertyDisposals/createAmendCgtPpdOverrides/def1/Def1_CreateAmendCgtPpdOverridesRulesValidatorSpec.scala
@@ -633,6 +633,15 @@ class Def1_CreateAmendCgtPpdOverridesRulesValidatorSpec extends UnitSpec with Mo
         )
       }
     }
+    "return RuleTaxYearForVersionNotSupportedError error" when {
+      "a tax year after the maximum tax year is supplied" in new Test {
+        val result: Either[ErrorWrapper, CreateAmendCgtPpdOverridesRequestData] =
+          validator(validNino, "2025-26", validRequestJson).validateAndWrapResult()
+        result shouldBe Left(
+          ErrorWrapper(correlationId, RuleTaxYearForVersionNotSupportedError)
+        )
+      }
+    }
 
     "return RuleIncorrectOrEmptyBodyError error" when {
 

--- a/test/v1/residentialPropertyDisposals/createAmendNonPpd/def1/Def1_CreateAmendCgtResidentialPropertyDisposalsValidatorSpec.scala
+++ b/test/v1/residentialPropertyDisposals/createAmendNonPpd/def1/Def1_CreateAmendCgtResidentialPropertyDisposalsValidatorSpec.scala
@@ -386,13 +386,22 @@ class Def1_CreateAmendCgtResidentialPropertyDisposalsValidatorSpec extends UnitS
     }
 
     "return RuleTaxYearNotSupportedError error" when {
-      "an invalid tax year is supplied" in new Test {
+      "a tax year before the minimum" in new Test {
         val result: Either[ErrorWrapper, CreateAmendCgtResidentialPropertyDisposalsRequestData] =
-          validator(validNino, "2017-18", validRequestBodyJson).validateAndWrapResult()
+          validator(validNino, "2018-19", validRequestBodyJson).validateAndWrapResult()
 
         result shouldBe Left(
           ErrorWrapper(correlationId, RuleTaxYearNotSupportedError)
         )
+      }
+    }
+
+    "return RuleTaxYearForVersionNotSupportedError error" when {
+      "a tax year after the maximum tax year is supplied" in new Test {
+        val result: Either[ErrorWrapper, CreateAmendCgtResidentialPropertyDisposalsRequestData] =
+          validator(validNino, "2025-26", validRequestBodyJson).validateAndWrapResult()
+
+        result shouldBe Left(ErrorWrapper(correlationId, RuleTaxYearForVersionNotSupportedError))
       }
     }
 

--- a/test/v1/residentialPropertyDisposals/deleteCgtPpdOverrides/def1/Def1_DeleteCgtPpdOverridesValidatorSpec.scala
+++ b/test/v1/residentialPropertyDisposals/deleteCgtPpdOverrides/def1/Def1_DeleteCgtPpdOverridesValidatorSpec.scala
@@ -73,10 +73,19 @@ class Def1_DeleteCgtPpdOverridesValidatorSpec extends UnitSpec with MockAppConfi
     }
 
     "return RuleTaxYearNotSupportedError error" when {
-      "an out of range tax year is supplied" in new Test {
+      "a tax year before the minimum tax year is supplied" in new Test {
         val result = validator(validNino, "2016-17").validateAndWrapResult()
         result shouldBe Left(
           ErrorWrapper(correlationId, RuleTaxYearNotSupportedError)
+        )
+      }
+    }
+
+    "return RuleTaxYearForVersionNotSupportedError error" when {
+      "a tax year after the maximum tax year is supplied" in new Test {
+        val result = validator(validNino, "2025-26").validateAndWrapResult()
+        result shouldBe Left(
+          ErrorWrapper(correlationId, RuleTaxYearForVersionNotSupportedError)
         )
       }
     }

--- a/test/v1/residentialPropertyDisposals/deleteNonPpd/DeleteCgtNonPpdConnectorSpec.scala
+++ b/test/v1/residentialPropertyDisposals/deleteNonPpd/DeleteCgtNonPpdConnectorSpec.scala
@@ -17,7 +17,9 @@
 package v1.residentialPropertyDisposals.deleteNonPpd
 
 import common.connectors.CgtConnectorSpec
+import play.api.Configuration
 import shared.models.domain.{Nino, TaxYear}
+import shared.models.errors.NinoFormatError
 import shared.models.outcomes.ResponseWrapper
 import uk.gov.hmrc.http.StringContextOps
 import v1.residentialPropertyDisposals.deleteNonPpd.def1.model.request.Def1_DeleteCgtNonPpdRequestData
@@ -29,10 +31,10 @@ class DeleteCgtNonPpdConnectorSpec extends CgtConnectorSpec {
 
   val nino: String = "AA111111A"
 
-  "DeleteCgtNonPpdConnectorSpec" when {
-    "deleteCgtNonPpd is called" must {
-      "return a 200 for success scenario" in new Api1661Test with Test {
-        def taxYear: TaxYear = TaxYear.fromMtd("2018-19")
+  "deleteCgtNonPpd" when {
+    "given a valid request (NON-TYS)" must {
+      "return a success response" in new Api1661Test with Test {
+        override def taxYear: TaxYear = TaxYear.fromMtd("2018-19")
 
         val outcome = Right(ResponseWrapper(correlationId, ()))
 
@@ -44,9 +46,9 @@ class DeleteCgtNonPpdConnectorSpec extends CgtConnectorSpec {
       }
     }
 
-    "deleteCgtNonPpd is called for a TaxYearSpecific tax year" must {
-      "return a 200 for success scenario" in new IfsTest with Test {
-        def taxYear: TaxYear = TaxYear.fromMtd("2023-24")
+    "given a valid request (TYS)" must {
+      "return a success response when feature switch is disabled (IFS enabled)" in new IfsTest with Test {
+        MockedSharedAppConfig.featureSwitchConfig.returns(Configuration("ifs_hip_migration_1875.enabled" -> false))
 
         val outcome = Right(ResponseWrapper(correlationId, ()))
 
@@ -55,11 +57,35 @@ class DeleteCgtNonPpdConnectorSpec extends CgtConnectorSpec {
 
         await(connector.deleteCgtNonPpd(request)) shouldBe outcome
       }
+
+      "return a success response when feature switch is enabled (HIP enabled)" in new HipTest with Test {
+        MockedSharedAppConfig.featureSwitchConfig.returns(Configuration("ifs_hip_migration_1875.enabled" -> true))
+
+        val outcome = Right(ResponseWrapper(correlationId, ()))
+
+        willDelete(url"$baseUrl/itsa/income-tax/v1/23-24/income/disposals/residential-property/$nino")
+          .returns(Future.successful(outcome))
+
+        await(connector.deleteCgtNonPpd(request)) shouldBe outcome
+      }
     }
+
+    "given a request returning an error" must {
+      "return an unsuccessful response with the correct correlationId and a single error" in new HipTest with Test {
+        MockedSharedAppConfig.featureSwitchConfig.returns(Configuration("ifs_hip_migration_1875.enabled" -> true))
+
+        val outcome: Left[ResponseWrapper[NinoFormatError.type], Nothing] = Left(ResponseWrapper(correlationId, NinoFormatError))
+
+        willDelete(url"$baseUrl/itsa/income-tax/v1/23-24/income/disposals/residential-property/$nino").returns(Future.successful(outcome))
+
+        await(connector.deleteCgtNonPpd(request)) shouldBe outcome
+      }
+    }
+
   }
 
   trait Test { self: ConnectorTest =>
-    def taxYear: TaxYear
+    def taxYear: TaxYear = TaxYear.fromMtd("2023-24")
 
     protected val connector: DeleteCgtNonPpdConnector = new DeleteCgtNonPpdConnector(http = mockHttpClient, appConfig = mockSharedAppConfig)
 

--- a/test/v1/residentialPropertyDisposals/deleteNonPpd/def1/Def1_DeleteCgtNonPpdValidatorSpec.scala
+++ b/test/v1/residentialPropertyDisposals/deleteNonPpd/def1/Def1_DeleteCgtNonPpdValidatorSpec.scala
@@ -81,11 +81,20 @@ class Def1_DeleteCgtNonPpdValidatorSpec extends UnitSpec with MockAppConfig {
     }
 
     "return RuleTaxYearNotSupportedError error" when {
-      "an invalid tax year is supplied" in new Test {
+      "a tax year before the minimum tax year is supplied" in new Test {
         val result: Either[ErrorWrapper, DeleteCgtNonPpdRequestData] =
           validator(validNino, "2018-19").validateAndWrapResult()
 
         result shouldBe Left(ErrorWrapper(correlationId, RuleTaxYearNotSupportedError))
+      }
+    }
+
+    "return RuleTaxYearForVersionNotSupportedError error" when {
+      "a tax year after the maximum tax year is supplied" in new Test {
+        val result: Either[ErrorWrapper, DeleteCgtNonPpdRequestData] =
+          validator(validNino, "2025-26").validateAndWrapResult()
+
+        result shouldBe Left(ErrorWrapper(correlationId, RuleTaxYearForVersionNotSupportedError))
       }
     }
 

--- a/test/v1/residentialPropertyDisposals/retrieveAll/def1/Def1_RetrieveAllResidentialPropertyCgtValidatorSpec.scala
+++ b/test/v1/residentialPropertyDisposals/retrieveAll/def1/Def1_RetrieveAllResidentialPropertyCgtValidatorSpec.scala
@@ -91,11 +91,20 @@ class Def1_RetrieveAllResidentialPropertyCgtValidatorSpec extends UnitSpec with 
     }
 
     "return RuleTaxYearNotSupportedError error" when {
-      "a tax year that is not supported is supplied" in new Test {
+      "a tax year that is below the minimum is supplied" in new Test {
         val result: Either[ErrorWrapper, RetrieveAllResidentialPropertyCgtRequestData] =
           validator(validNino, "2018-19", validSource).validateAndWrapResult()
 
         result shouldBe Left(ErrorWrapper(correlationId, RuleTaxYearNotSupportedError))
+      }
+    }
+
+    "return RuleTaxYearForVersionNotSupportedError error" when {
+      "a tax year that is above the maximum is supplied" in new Test {
+        val result: Either[ErrorWrapper, RetrieveAllResidentialPropertyCgtRequestData] =
+          validator(validNino, "2025-26", validSource).validateAndWrapResult()
+
+        result shouldBe Left(ErrorWrapper(correlationId, RuleTaxYearForVersionNotSupportedError))
       }
     }
 

--- a/test/v2/otherCgt/createAmend/def1/Def1_CreateAmendOtherCgtRulesValidatorSpec.scala
+++ b/test/v2/otherCgt/createAmend/def1/Def1_CreateAmendOtherCgtRulesValidatorSpec.scala
@@ -159,6 +159,12 @@ class Def1_CreateAmendOtherCgtRulesValidatorSpec extends UnitSpec with MockAppCo
       }
     }
 
+    "return RuleTaxYearForVersionNotSupportedError error" when {
+      "a tax year after the maximum tax year is supplied" in new Test {
+        validate(taxYear = "2025-26") shouldBe error(RuleTaxYearForVersionNotSupportedError)
+      }
+    }
+
     "return RuleTaxYearRangeInvalidError error" when {
       "an invalid tax year range is supplied" in new Test {
         validate(taxYear = "2017-19") shouldBe error(RuleTaxYearRangeInvalidError)

--- a/test/v2/otherCgt/delete/DeleteOtherCgtConnectorSpec.scala
+++ b/test/v2/otherCgt/delete/DeleteOtherCgtConnectorSpec.scala
@@ -17,6 +17,7 @@
 package v2.otherCgt.delete
 
 import common.connectors.CgtConnectorSpec
+import play.api.Configuration
 import shared.models.domain.{Nino, TaxYear}
 import shared.models.outcomes.ResponseWrapper
 import uk.gov.hmrc.http.StringContextOps
@@ -28,8 +29,9 @@ import scala.concurrent.Future
 class DeleteOtherCgtConnectorSpec extends CgtConnectorSpec {
 
   "DeleteOtherCgtConnector" should {
-    "return the expected response for a non-TYS request" when {
+    "return the expected response for a non-TYS IFS request" when {
       "a valid request is made" in new Api1661Test with Test {
+        MockedSharedAppConfig.featureSwitchConfig returns Configuration("ifs_hip_migration_1953.enabled" -> false)
         def taxYear: TaxYear = TaxYear.fromMtd("2019-20")
         val outcome          = Right(ResponseWrapper(correlationId, ()))
 
@@ -40,13 +42,29 @@ class DeleteOtherCgtConnectorSpec extends CgtConnectorSpec {
         await(connector.deleteOtherCgt(request)) shouldBe outcome
       }
     }
-    "return the expected response for a TYS request" when {
+    "return the expected response for a TYS IFS request" when {
       "a valid request is made" in new IfsTest with Test {
+        MockedSharedAppConfig.featureSwitchConfig returns Configuration("ifs_hip_migration_1953.enabled" -> false)
         def taxYear: TaxYear = TaxYear.fromMtd("2023-24")
         val outcome          = Right(ResponseWrapper(correlationId, ()))
 
         willDelete(
           url = url"$baseUrl/income-tax/income/disposals/other-gains/23-24/$nino"
+        ).returns(Future.successful(outcome))
+
+        await(connector.deleteOtherCgt(request)) shouldBe outcome
+      }
+    }
+    "return the expected response for a HIP request" when {
+      "a valid request is made" in new HipTest with Test {
+        MockedSharedAppConfig.featureSwitchConfig returns Configuration("ifs_hip_migration_1953.enabled" -> true)
+
+        def taxYear: TaxYear = TaxYear.fromMtd("2023-24")
+
+        val outcome = Right(ResponseWrapper(correlationId, ()))
+
+        willDelete(
+          url = url"$baseUrl/itsa/income-tax/v1/23-24/income/disposals/other-gains/$nino"
         ).returns(Future.successful(outcome))
 
         await(connector.deleteOtherCgt(request)) shouldBe outcome

--- a/test/v2/otherCgt/delete/def1/Def1_DeleteOtherCgtValidatorSpec.scala
+++ b/test/v2/otherCgt/delete/def1/Def1_DeleteOtherCgtValidatorSpec.scala
@@ -88,6 +88,15 @@ class Def1_DeleteOtherCgtValidatorSpec extends UnitSpec with MockAppConfig {
       }
     }
 
+    "return RuleTaxYearForVersionNotSupportedError error" when {
+      "a tax year that is not supported by this version is supplied" in new Test {
+        val result: Either[ErrorWrapper, DeleteOtherCgtRequestData] =
+          validator(validNino, "2025-26")
+
+        result shouldBe Left(ErrorWrapper(correlationId, RuleTaxYearForVersionNotSupportedError))
+      }
+    }
+
     "return multiple errors" when {
       "request supplied has multiple errors" in new Test {
         val result: Either[ErrorWrapper, DeleteOtherCgtRequestData] =

--- a/test/v2/otherCgt/retrieve/RetrieveOtherCgtValidatorFactorySpec.scala
+++ b/test/v2/otherCgt/retrieve/RetrieveOtherCgtValidatorFactorySpec.scala
@@ -31,6 +31,7 @@ class RetrieveOtherCgtValidatorFactorySpec extends UnitSpec with MockAppConfig {
     "return the Def1 validator" when {
       "given a request handled by a Def1 schema" in {
         val result = validatorFactory.validator(validNino, validTaxYear)
+
         result shouldBe a[Def1_RetrieveOtherCgtValidator]
       }
     }

--- a/test/v2/otherCgt/retrieve/def1/Def1_RetrieveOtherCgtValidatorSpec.scala
+++ b/test/v2/otherCgt/retrieve/def1/Def1_RetrieveOtherCgtValidatorSpec.scala
@@ -21,6 +21,7 @@ import shared.models.domain.{Nino, TaxYear}
 import shared.models.errors.*
 import support.UnitSpec
 import v2.otherCgt.retrieve.def1.model.request.Def1_RetrieveOtherCgtRequestData
+import v2.otherCgt.retrieve.model.request.RetrieveOtherCgtRequestData
 
 class Def1_RetrieveOtherCgtValidatorSpec extends UnitSpec with MockAppConfig {
 
@@ -45,50 +46,55 @@ class Def1_RetrieveOtherCgtValidatorSpec extends UnitSpec with MockAppConfig {
   "validator" should {
     "return the parsed domain object" when {
       "a valid request is supplied" in new Test {
-        val result = validator(validNino, validTaxYear)
+        val result: Either[ErrorWrapper, RetrieveOtherCgtRequestData] = validator(validNino, validTaxYear)
+
         result shouldBe Right(Def1_RetrieveOtherCgtRequestData(parsedNino, parsedTaxYear))
       }
     }
 
     "return NinoFormatError error" when {
       "an invalid nino is supplied" in new Test {
-        val result = validator("A12344A", validTaxYear)
-        result shouldBe Left(
-          ErrorWrapper(correlationId, NinoFormatError)
-        )
+        val result: Either[ErrorWrapper, RetrieveOtherCgtRequestData] = validator("A12344A", validTaxYear)
+
+        result shouldBe Left(ErrorWrapper(correlationId, NinoFormatError))
       }
     }
 
     "return TaxYearFormatError error" when {
       "an invalid tax year is supplied" in new Test {
-        val result = validator(validNino, "201718")
-        result shouldBe Left(
-          ErrorWrapper(correlationId, TaxYearFormatError)
-        )
+        val result: Either[ErrorWrapper, RetrieveOtherCgtRequestData] = validator(validNino, "201718")
+
+        result shouldBe Left(ErrorWrapper(correlationId, TaxYearFormatError))
       }
     }
 
     "return RuleTaxYearNotSupportedError error" when {
-      "an out of range tax year is supplied" in new Test {
-        val result = validator(validNino, "2016-17")
-        result shouldBe Left(
-          ErrorWrapper(correlationId, RuleTaxYearNotSupportedError)
-        )
+      "a tax year before the minimum tax year is supplied" in new Test {
+        val result: Either[ErrorWrapper, RetrieveOtherCgtRequestData] = validator(validNino, "2016-17")
+
+        result shouldBe Left(ErrorWrapper(correlationId, RuleTaxYearNotSupportedError))
+      }
+    }
+
+    "return RuleTaxYearForVersionNotSupportedError error" when {
+      "a tax year after the maximum tax year is supplied" in new Test {
+        val result: Either[ErrorWrapper, RetrieveOtherCgtRequestData] = validator(validNino, "2025-26")
+
+        result shouldBe Left(ErrorWrapper(correlationId, RuleTaxYearForVersionNotSupportedError))
       }
     }
 
     "return RuleTaxYearRangeInvalidError error" when {
       "an invalid tax year range is supplied" in new Test {
-        val result = validator(validNino, "2017-19")
-        result shouldBe Left(
-          ErrorWrapper(correlationId, RuleTaxYearRangeInvalidError)
-        )
+        val result: Either[ErrorWrapper, RetrieveOtherCgtRequestData] = validator(validNino, "2017-19")
+
+        result shouldBe Left(ErrorWrapper(correlationId, RuleTaxYearRangeInvalidError))
       }
     }
 
     "return multiple errors" when {
       "multiple invalid parameters are provided" in new Test {
-        val result = validator("not-a-nino", "2017-19")
+        val result: Either[ErrorWrapper, RetrieveOtherCgtRequestData] = validator("not-a-nino", "2017-19")
 
         result shouldBe Left(
           ErrorWrapper(

--- a/test/v2/residentialPropertyDisposals/createAmendCgtPpdOverrides/CreateAmendCgtPpdOverridesConnectorSpec.scala
+++ b/test/v2/residentialPropertyDisposals/createAmendCgtPpdOverrides/CreateAmendCgtPpdOverridesConnectorSpec.scala
@@ -17,8 +17,8 @@
 package v2.residentialPropertyDisposals.createAmendCgtPpdOverrides
 
 import common.connectors.CgtConnectorSpec
-import shared.config.MockSharedAppConfig
-import shared.mocks.MockHttpClient
+import play.api.Configuration
+import shared.connectors.DownstreamOutcome
 import shared.models.domain.{Nino, TaxYear}
 import shared.models.outcomes.ResponseWrapper
 import uk.gov.hmrc.http.{HeaderCarrier, StringContextOps}
@@ -29,11 +29,19 @@ import scala.concurrent.Future
 
 class CreateAmendCgtPpdOverridesConnectorSpec extends CgtConnectorSpec {
 
-  trait Test extends MockHttpClient with MockSharedAppConfig {
+  trait Test {
+    self: ConnectorTest =>
 
-    val nino: String = "AA111111A"
+    def taxYear: TaxYear = TaxYear.fromMtd("2023-24")
+    val nino: String     = "AA111111A"
 
-    val connector: CreateAmendCgtPpdOverridesConnector = new CreateAmendCgtPpdOverridesConnector(
+    val request = Def1_CreateAmendCgtPpdOverridesRequestData(
+      nino = Nino(nino),
+      taxYear = taxYear,
+      body = requestBodyModel
+    )
+
+    protected val connector: CreateAmendCgtPpdOverridesConnector = new CreateAmendCgtPpdOverridesConnector(
       http = mockHttpClient,
       appConfig = mockSharedAppConfig
     )
@@ -44,13 +52,7 @@ class CreateAmendCgtPpdOverridesConnectorSpec extends CgtConnectorSpec {
     "createAndAmend" must {
       "return a 204 status for a success scenario" in new Api1661Test with Test {
 
-        val taxYear = TaxYear.fromMtd("2019-20")
-
-        val request = Def1_CreateAmendCgtPpdOverridesRequestData(
-          nino = Nino(nino),
-          taxYear,
-          body = requestBodyModel
-        )
+        override def taxYear = TaxYear.fromMtd("2019-20")
 
         val outcome = Right(ResponseWrapper(correlationId, ()))
 
@@ -65,19 +67,13 @@ class CreateAmendCgtPpdOverridesConnectorSpec extends CgtConnectorSpec {
     }
 
     "createAndAmend called for a Tax Year Specific tax year" must {
-      "return a 200 status for a success scenario" in
-        new IfsTest with Test {
-          def taxYear: TaxYear = TaxYear.fromMtd("2023-24")
+      "return a 200 status for a success scenario" when {
+        "the downstream request to IFS is successful" in new IfsTest with Test {
 
+          MockedSharedAppConfig.featureSwitchConfig.returns(Configuration("ifs_hip_migration_1946.enabled" -> false))
           implicit val hc: HeaderCarrier = HeaderCarrier(otherHeaders = otherHeaders ++ Seq("Content-Type" -> "application/json"))
 
           val outcome = Right(ResponseWrapper(correlationId, ()))
-
-          val request = Def1_CreateAmendCgtPpdOverridesRequestData(
-            nino = Nino(nino),
-            taxYear,
-            body = requestBodyModel
-          )
 
           willPut(
             url"$baseUrl/income-tax/income/disposals/residential-property/ppd/${taxYear.asTysDownstream}/${nino}",
@@ -87,6 +83,18 @@ class CreateAmendCgtPpdOverridesConnectorSpec extends CgtConnectorSpec {
           val result = await(connector.createAmend(request))
           result shouldBe outcome
         }
+
+        "the downstream request to HIP is successful" in new HipTest with Test {
+          MockedSharedAppConfig.featureSwitchConfig.returns(Configuration("ifs_hip_migration_1946.enabled" -> true))
+          val outcome: Right[Nothing, ResponseWrapper[Unit]] = Right(ResponseWrapper(correlationId, ()))
+
+          willPut(url"$baseUrl/itsa/income-tax/v1/${taxYear.asTysDownstream}/income/disposals/residential-property/ppd/$nino", requestBodyModel)
+            .returns(Future.successful(outcome))
+
+          val result: DownstreamOutcome[Unit] = await(connector.createAmend(request))
+          result shouldBe outcome
+        }
+      }
     }
 
   }

--- a/test/v2/residentialPropertyDisposals/createAmendCgtPpdOverrides/CreateAmendCgtPpdOverridesValidatorFactorySpec.scala
+++ b/test/v2/residentialPropertyDisposals/createAmendCgtPpdOverrides/CreateAmendCgtPpdOverridesValidatorFactorySpec.scala
@@ -25,7 +25,7 @@ import v2.residentialPropertyDisposals.createAmendCgtPpdOverrides.def1.Def1_Crea
 class CreateAmendCgtPpdOverridesValidatorFactorySpec extends UnitSpec with JsonErrorValidators with MockAppConfig {
 
   private val validNino    = "AA123456A"
-  private val validTaxYear = "2021-22"
+  private val validTaxYear = "2019-20"
 
   def requestBodyJson(): JsValue = Json.parse(
     s"""

--- a/test/v2/residentialPropertyDisposals/createAmendCgtPpdOverrides/def1/Def1_CreateAmendCgtPpdOverridesRulesValidatorSpec.scala
+++ b/test/v2/residentialPropertyDisposals/createAmendCgtPpdOverrides/def1/Def1_CreateAmendCgtPpdOverridesRulesValidatorSpec.scala
@@ -634,6 +634,16 @@ class Def1_CreateAmendCgtPpdOverridesRulesValidatorSpec extends UnitSpec with Mo
       }
     }
 
+    "return RuleTaxYearForVersionNotSupportedError error" when {
+      "a tax year after the maximum tax year is supplied" in new Test {
+        val result: Either[ErrorWrapper, CreateAmendCgtPpdOverridesRequestData] =
+          validator(validNino, "2025-26", validRequestJson).validateAndWrapResult()
+        result shouldBe Left(
+          ErrorWrapper(correlationId, RuleTaxYearForVersionNotSupportedError)
+        )
+      }
+    }
+
     "return RuleIncorrectOrEmptyBodyError error" when {
 
       "a non-empty JSON body is submitted without any expected fields" in new Test {

--- a/test/v2/residentialPropertyDisposals/createAmendNonPpd/CreateAmendCgtResidentialPropertyDisposalsConnectorSpec.scala
+++ b/test/v2/residentialPropertyDisposals/createAmendNonPpd/CreateAmendCgtResidentialPropertyDisposalsConnectorSpec.scala
@@ -17,6 +17,7 @@
 package v2.residentialPropertyDisposals.createAmendNonPpd
 
 import common.connectors.CgtConnectorSpec
+import play.api.Configuration
 import shared.models.domain.{Nino, TaxYear}
 import shared.models.outcomes.ResponseWrapper
 import uk.gov.hmrc.http.StringContextOps
@@ -52,7 +53,7 @@ class CreateAmendCgtResidentialPropertyDisposalsConnectorSpec extends CgtConnect
       "a valid request is made" in new Api1661Test with Test {
         def taxYear: TaxYear = TaxYear.fromMtd("2019-20")
 
-        val outcome = Right(ResponseWrapper(correlationId, ()))
+        val outcome: Right[Nothing, ResponseWrapper[Unit]] = Right(ResponseWrapper(correlationId, ()))
 
         willPut(
           url = url"$baseUrl/income-tax/income/disposals/residential-property/$nino/2019-20",
@@ -63,13 +64,30 @@ class CreateAmendCgtResidentialPropertyDisposalsConnectorSpec extends CgtConnect
         await(connector.createAndAmend(createAmendCgtResidentialPropertyDisposalsRequest)) shouldBe outcome
       }
 
-      "a valid request is made for a TYS tax year" in new IfsTest with Test {
+      "a valid request is made for a TYS tax year on IFS" in new IfsTest with Test {
+        MockedSharedAppConfig.featureSwitchConfig.returns(Configuration("ifs_hip_migration_1952.enabled" -> false))
         def taxYear: TaxYear = TaxYear.fromMtd("2023-24")
 
-        val outcome = Right(ResponseWrapper(correlationId, ()))
+        val outcome: Right[Nothing, ResponseWrapper[Unit]] = Right(ResponseWrapper(correlationId, ()))
 
         willPut(
           url = url"$baseUrl/income-tax/income/disposals/residential-property/23-24/$nino",
+          body = requestBody
+        )
+          .returns(Future.successful(outcome))
+
+        await(connector.createAndAmend(createAmendCgtResidentialPropertyDisposalsRequest)) shouldBe outcome
+      }
+
+      "a valid request is made for a TYS tax year on HIP" in new HipTest with Test {
+        MockedSharedAppConfig.featureSwitchConfig.returns(Configuration("ifs_hip_migration_1952.enabled" -> true))
+
+        def taxYear: TaxYear = TaxYear.fromMtd("2023-24")
+
+        val outcome: Right[Nothing, ResponseWrapper[Unit]] = Right(ResponseWrapper(correlationId, ()))
+
+        willPut(
+          url = url"$baseUrl/itsa/income-tax/v1/23-24/income/disposals/residential-property/$nino",
           body = requestBody
         )
           .returns(Future.successful(outcome))

--- a/test/v2/residentialPropertyDisposals/createAmendNonPpd/def1/Def1_CreateAmendCgtResidentialPropertyDisposalsValidatorSpec.scala
+++ b/test/v2/residentialPropertyDisposals/createAmendNonPpd/def1/Def1_CreateAmendCgtResidentialPropertyDisposalsValidatorSpec.scala
@@ -386,13 +386,22 @@ class Def1_CreateAmendCgtResidentialPropertyDisposalsValidatorSpec extends UnitS
     }
 
     "return RuleTaxYearNotSupportedError error" when {
-      "an invalid tax year is supplied" in new Test {
+      "a tax year before the minimum" in new Test {
         val result: Either[ErrorWrapper, CreateAmendCgtResidentialPropertyDisposalsRequestData] =
-          validator(validNino, "2017-18", validRequestBodyJson).validateAndWrapResult()
+          validator(validNino, "2018-19", validRequestBodyJson).validateAndWrapResult()
 
         result shouldBe Left(
           ErrorWrapper(correlationId, RuleTaxYearNotSupportedError)
         )
+      }
+    }
+
+    "return RuleTaxYearForVersionNotSupportedError error" when {
+      "a tax year after the maximum tax year is supplied" in new Test {
+        val result: Either[ErrorWrapper, CreateAmendCgtResidentialPropertyDisposalsRequestData] =
+          validator(validNino, "2025-26", validRequestBodyJson).validateAndWrapResult()
+
+        result shouldBe Left(ErrorWrapper(correlationId, RuleTaxYearForVersionNotSupportedError))
       }
     }
 

--- a/test/v2/residentialPropertyDisposals/deleteCgtPpdOverrides/DeleteCgtPpdOverridesConnectorSpec.scala
+++ b/test/v2/residentialPropertyDisposals/deleteCgtPpdOverrides/DeleteCgtPpdOverridesConnectorSpec.scala
@@ -16,6 +16,7 @@
 
 package v2.residentialPropertyDisposals.deleteCgtPpdOverrides
 
+import play.api.Configuration
 import shared.connectors.ConnectorSpec
 import shared.models.domain.{Nino, TaxYear}
 import shared.models.errors.{InternalError, NinoFormatError}
@@ -46,7 +47,7 @@ class DeleteCgtPpdOverridesConnectorSpec extends ConnectorSpec {
 
   "Delete" should {
     "return the expected response for a non-TYS request" when {
-      "a valid request is made" in new DesTest with Test {
+      "a valid request is made" in new IfsTest with Test {
         def taxYear: TaxYear = TaxYear.fromMtd("2019-20")
 
         val outcome = Right(ResponseWrapper(correlationId, ()))
@@ -58,7 +59,7 @@ class DeleteCgtPpdOverridesConnectorSpec extends ConnectorSpec {
         await(connector.deleteCgtPpdOverrides(request)) shouldBe outcome
       }
 
-      "downstream returns a single error" in new DesTest with Test {
+      "downstream returns a single error" in new IfsTest with Test {
         def taxYear: TaxYear = TaxYear.fromMtd("2019-20")
 
         val outcome = Left(ResponseWrapper(correlationId, NinoFormatError))
@@ -70,7 +71,7 @@ class DeleteCgtPpdOverridesConnectorSpec extends ConnectorSpec {
         await(connector.deleteCgtPpdOverrides(request)) shouldBe outcome
       }
 
-      "downstream returns multiple errors" in new DesTest with Test {
+      "downstream returns multiple errors" in new IfsTest with Test {
 
         def taxYear: TaxYear = TaxYear.fromMtd("2019-20")
 
@@ -87,11 +88,26 @@ class DeleteCgtPpdOverridesConnectorSpec extends ConnectorSpec {
     "return the expected response for a TYS request" when {
       "a valid request is made" in new IfsTest with Test {
         def taxYear: TaxYear = TaxYear.fromMtd("2023-24")
+        MockedSharedAppConfig.featureSwitchConfig returns Configuration("ifs_hip_migration_1947.enabled" -> false)
 
         val outcome = Right(ResponseWrapper(correlationId, ()))
 
         willDelete(
           url"$baseUrl/income-tax/income/disposals/residential-property/ppd/${taxYear.asTysDownstream}/$nino"
+        ).returns(Future.successful(outcome))
+
+        await(connector.deleteCgtPpdOverrides(request)) shouldBe outcome
+      }
+    }
+    "return the expected response for a HIP request" when {
+      "a valid request is made" in new HipTest with Test {
+        def taxYear: TaxYear = TaxYear.fromMtd("2024-25")
+        MockedSharedAppConfig.featureSwitchConfig returns Configuration("ifs_hip_migration_1947.enabled" -> true)
+
+        val outcome = Right(ResponseWrapper(correlationId, ()))
+
+        willDelete(
+          url"$baseUrl/itsa/income-tax/v1/${taxYear.asTysDownstream}/income/disposals/residential-property/ppd/$nino"
         ).returns(Future.successful(outcome))
 
         await(connector.deleteCgtPpdOverrides(request)) shouldBe outcome

--- a/test/v2/residentialPropertyDisposals/deleteCgtPpdOverrides/def1/Def1_DeleteCgtPpdOverridesValidatorSpec.scala
+++ b/test/v2/residentialPropertyDisposals/deleteCgtPpdOverrides/def1/Def1_DeleteCgtPpdOverridesValidatorSpec.scala
@@ -73,10 +73,19 @@ class Def1_DeleteCgtPpdOverridesValidatorSpec extends UnitSpec with MockAppConfi
     }
 
     "return RuleTaxYearNotSupportedError error" when {
-      "an out of range tax year is supplied" in new Test {
+      "a tax year before the minimum tax year is supplied" in new Test {
         val result = validator(validNino, "2016-17").validateAndWrapResult()
         result shouldBe Left(
           ErrorWrapper(correlationId, RuleTaxYearNotSupportedError)
+        )
+      }
+    }
+
+    "return RuleTaxYearForVersionNotSupportedError error" when {
+      "a tax year after the maximum tax year is supplied" in new Test {
+        val result = validator(validNino, "2025-26").validateAndWrapResult()
+        result shouldBe Left(
+          ErrorWrapper(correlationId, RuleTaxYearForVersionNotSupportedError)
         )
       }
     }

--- a/test/v2/residentialPropertyDisposals/deleteNonPpd/DeleteCgtNonPpdConnectorSpec.scala
+++ b/test/v2/residentialPropertyDisposals/deleteNonPpd/DeleteCgtNonPpdConnectorSpec.scala
@@ -17,7 +17,9 @@
 package v2.residentialPropertyDisposals.deleteNonPpd
 
 import common.connectors.CgtConnectorSpec
+import play.api.Configuration
 import shared.models.domain.{Nino, TaxYear}
+import shared.models.errors.NinoFormatError
 import shared.models.outcomes.ResponseWrapper
 import uk.gov.hmrc.http.StringContextOps
 import v2.residentialPropertyDisposals.deleteNonPpd.def1.model.request.Def1_DeleteCgtNonPpdRequestData
@@ -29,10 +31,10 @@ class DeleteCgtNonPpdConnectorSpec extends CgtConnectorSpec {
 
   val nino: String = "AA111111A"
 
-  "DeleteCgtNonPpdConnectorSpec" when {
-    "deleteCgtNonPpd is called" must {
-      "return a 200 for success scenario" in new Api1661Test with Test {
-        def taxYear: TaxYear = TaxYear.fromMtd("2018-19")
+  "deleteCgtNonPpd" when {
+    "given a valid request (NON-TYS)" must {
+      "return a success response" in new Api1661Test with Test {
+        override def taxYear: TaxYear = TaxYear.fromMtd("2018-19")
 
         val outcome = Right(ResponseWrapper(correlationId, ()))
 
@@ -44,9 +46,9 @@ class DeleteCgtNonPpdConnectorSpec extends CgtConnectorSpec {
       }
     }
 
-    "deleteCgtNonPpd is called for a TaxYearSpecific tax year" must {
-      "return a 200 for success scenario" in new IfsTest with Test {
-        def taxYear: TaxYear = TaxYear.fromMtd("2023-24")
+    "given a valid request (TYS)" must {
+      "return a success response when feature switch is disabled (IFS enabled)" in new IfsTest with Test {
+        MockedSharedAppConfig.featureSwitchConfig.returns(Configuration("ifs_hip_migration_1875.enabled" -> false))
 
         val outcome = Right(ResponseWrapper(correlationId, ()))
 
@@ -55,11 +57,35 @@ class DeleteCgtNonPpdConnectorSpec extends CgtConnectorSpec {
 
         await(connector.deleteCgtNonPpd(request)) shouldBe outcome
       }
+
+      "return a success response when feature switch is enabled (HIP enabled)" in new HipTest with Test {
+        MockedSharedAppConfig.featureSwitchConfig.returns(Configuration("ifs_hip_migration_1875.enabled" -> true))
+
+        val outcome = Right(ResponseWrapper(correlationId, ()))
+
+        willDelete(url"$baseUrl/itsa/income-tax/v1/23-24/income/disposals/residential-property/$nino")
+          .returns(Future.successful(outcome))
+
+        await(connector.deleteCgtNonPpd(request)) shouldBe outcome
+      }
     }
+
+    "given a request returning an error" must {
+      "return an unsuccessful response with the correct correlationId and a single error" in new HipTest with Test {
+        MockedSharedAppConfig.featureSwitchConfig.returns(Configuration("ifs_hip_migration_1875.enabled" -> true))
+
+        val outcome: Left[ResponseWrapper[NinoFormatError.type], Nothing] = Left(ResponseWrapper(correlationId, NinoFormatError))
+
+        willDelete(url"$baseUrl/itsa/income-tax/v1/23-24/income/disposals/residential-property/$nino").returns(Future.successful(outcome))
+
+        await(connector.deleteCgtNonPpd(request)) shouldBe outcome
+      }
+    }
+
   }
 
   trait Test { self: ConnectorTest =>
-    def taxYear: TaxYear
+    def taxYear: TaxYear = TaxYear.fromMtd("2023-24")
 
     protected val connector: DeleteCgtNonPpdConnector = new DeleteCgtNonPpdConnector(http = mockHttpClient, appConfig = mockSharedAppConfig)
 

--- a/test/v2/residentialPropertyDisposals/deleteNonPpd/def1/Def1_DeleteCgtNonPpdValidatorSpec.scala
+++ b/test/v2/residentialPropertyDisposals/deleteNonPpd/def1/Def1_DeleteCgtNonPpdValidatorSpec.scala
@@ -81,11 +81,20 @@ class Def1_DeleteCgtNonPpdValidatorSpec extends UnitSpec with MockAppConfig {
     }
 
     "return RuleTaxYearNotSupportedError error" when {
-      "an invalid tax year is supplied" in new Test {
+      "a tax year before the minimum tax year is supplied" in new Test {
         val result: Either[ErrorWrapper, DeleteCgtNonPpdRequestData] =
           validator(validNino, "2018-19").validateAndWrapResult()
 
         result shouldBe Left(ErrorWrapper(correlationId, RuleTaxYearNotSupportedError))
+      }
+    }
+
+    "return RuleTaxYearForVersionNotSupportedError error" when {
+      "a tax year after the maximum tax year is supplied" in new Test {
+        val result: Either[ErrorWrapper, DeleteCgtNonPpdRequestData] =
+          validator(validNino, "2025-26").validateAndWrapResult()
+
+        result shouldBe Left(ErrorWrapper(correlationId, RuleTaxYearForVersionNotSupportedError))
       }
     }
 

--- a/test/v2/residentialPropertyDisposals/retrieveAll/RetrieveAllResidentialPropertyCgtConnectorSpec.scala
+++ b/test/v2/residentialPropertyDisposals/retrieveAll/RetrieveAllResidentialPropertyCgtConnectorSpec.scala
@@ -17,6 +17,7 @@
 package v2.residentialPropertyDisposals.retrieveAll
 
 import org.scalamock.handlers.CallHandler
+import play.api.Configuration
 import shared.connectors.{ConnectorSpec, DownstreamOutcome}
 import shared.models.domain.{Nino, TaxYear}
 import shared.models.outcomes.ResponseWrapper
@@ -59,7 +60,7 @@ class RetrieveAllResidentialPropertyCgtConnectorSpec extends ConnectorSpec {
       ).returns(Future.successful(outcome))
     }
 
-    protected def stubTysHttpResponse(outcome: DownstreamOutcome[RetrieveAllResidentialPropertyCgtResponse])
+    protected def stubTysIfsHttpResponse(outcome: DownstreamOutcome[RetrieveAllResidentialPropertyCgtResponse])
         : CallHandler[Future[DownstreamOutcome[RetrieveAllResidentialPropertyCgtResponse]]]#Derived = {
       willGet(
         url = url"$baseUrl/income-tax/income/disposals/residential-property/${taxYear.asTysDownstream}/$nino",
@@ -67,29 +68,46 @@ class RetrieveAllResidentialPropertyCgtConnectorSpec extends ConnectorSpec {
       ).returns(Future.successful(outcome))
     }
 
+    protected def stubTysHipHttpResponse(outcome: DownstreamOutcome[RetrieveAllResidentialPropertyCgtResponse])
+        : CallHandler[Future[DownstreamOutcome[RetrieveAllResidentialPropertyCgtResponse]]]#Derived = {
+      willGet(
+        url = url"$baseUrl/itsa/income-tax/v1/${taxYear.asTysDownstream}/income/disposals/residential-property/$nino",
+        queryParams
+      ).returns(Future.successful(outcome))
+    }
+
   }
 
-  "RetrieveAllResidentialPropertyCgtConnector" when {
+  "RetrieveAllResidentialPropertyCgtConnector" must {
 
-    "retrieveAllResidentialPropertyCgt" must {
-      "return a 200 status for a success scenario" in new DesTest with Test {
+    "return a 200 status for a success scenario for Non-TYS tax years" in new DesTest with Test {
 
-        val outcome = Right(ResponseWrapper(correlationId, response))
+      val outcome = Right(ResponseWrapper(correlationId, response))
 
-        stubHttpResponse(outcome)
+      stubHttpResponse(outcome)
+
+      val result: DownstreamOutcome[RetrieveAllResidentialPropertyCgtResponse] = await(connector.retrieve(request))
+      result shouldBe outcome
+    }
+  }
+
+  "retrieveAllResidentialPropertyCgt for Tax Year Specific (TYS)" must {
+    "return a 200 status for a success scenario for TYS tax Years" when {
+      "the downstream is IFS" in new IfsTest with Test {
+        override def taxYear: TaxYear = TaxYear.fromMtd("2023-24")
+        val outcome                   = Right(ResponseWrapper(correlationId, response))
+
+        MockedSharedAppConfig.featureSwitchConfig.returns(Configuration("ifs_hip_migration_1881.enabled" -> false))
+        stubTysIfsHttpResponse(outcome)
 
         val result: DownstreamOutcome[RetrieveAllResidentialPropertyCgtResponse] = await(connector.retrieve(request))
         result shouldBe outcome
       }
-    }
-
-    "retrieveAllResidentialPropertyCgt for Tax Year Specific (TYS)" must {
-      "return a 200 status for a success scenario" in new IfsTest with Test {
+      "the downstream is HIP" in new HipTest with Test {
         override def taxYear: TaxYear = TaxYear.fromMtd("2023-24")
-
-        val outcome = Right(ResponseWrapper(correlationId, response))
-
-        stubTysHttpResponse(outcome)
+        val outcome                   = Right(ResponseWrapper(correlationId, response))
+        MockedSharedAppConfig.featureSwitchConfig.returns(Configuration("ifs_hip_migration_1881.enabled" -> true))
+        stubTysHipHttpResponse(outcome)
 
         val result: DownstreamOutcome[RetrieveAllResidentialPropertyCgtResponse] = await(connector.retrieve(request))
         result shouldBe outcome

--- a/test/v2/residentialPropertyDisposals/retrieveAll/def1/Def1_RetrieveAllResidentialPropertyCgtValidatorSpec.scala
+++ b/test/v2/residentialPropertyDisposals/retrieveAll/def1/Def1_RetrieveAllResidentialPropertyCgtValidatorSpec.scala
@@ -91,11 +91,20 @@ class Def1_RetrieveAllResidentialPropertyCgtValidatorSpec extends UnitSpec with 
     }
 
     "return RuleTaxYearNotSupportedError error" when {
-      "a tax year that is not supported is supplied" in new Test {
+      "a tax year that is below the minimum is supplied" in new Test {
         val result: Either[ErrorWrapper, RetrieveAllResidentialPropertyCgtRequestData] =
           validator(validNino, "2018-19", validSource).validateAndWrapResult()
 
         result shouldBe Left(ErrorWrapper(correlationId, RuleTaxYearNotSupportedError))
+      }
+    }
+
+    "return RuleTaxYearForVersionNotSupportedError error" when {
+      "a tax year that is above the maximum is supplied" in new Test {
+        val result: Either[ErrorWrapper, RetrieveAllResidentialPropertyCgtRequestData] =
+          validator(validNino, "2025-26", validSource).validateAndWrapResult()
+
+        result shouldBe Left(ErrorWrapper(correlationId, RuleTaxYearForVersionNotSupportedError))
       }
     }
 


### PR DESCRIPTION
The following endpoints have been migration to HIP:

- Retrieve All CGT Residential Property Disposals and Overrides
- Create and Amend CGT Residential Property Disposals (non-PPD)
- Delete CGT Residential Property Disposals (non-PPD)
- Create and Amend 'Report and Pay Capital Gains Tax on Residential Property' Overrides (PPD)
- Delete 'Report and Pay Capital Gains Tax on Residential Property' Overrides (PPD)
- Retrieve Other Capital Gains and Disposals
- Create and Amend Other Capital Gains and Disposals
- Delete Other Capital Gains and Disposals